### PR TITLE
Correct computation of he per baseline E_pq term.

### DIFF
--- a/montblanc/BaseSharedData.py
+++ b/montblanc/BaseSharedData.py
@@ -543,7 +543,7 @@ class GPUSharedData(BaseSharedData):
 
             assert E_q.shape == (sd.nbl, sd.nchan, sd.ntime, sd.nsrc)
 
-            return E_p*E_q
+            return E_p/E_q
         except AttributeError as e:
             self.rethrow_attribute_exception(e)
 

--- a/montblanc/RimeEBK.py
+++ b/montblanc/RimeEBK.py
@@ -229,7 +229,7 @@ void rime_jones_EBK_impl(
         E_q = Po::min(E_q, E_beam_clip);
         E_q = Po::cos(E_q);
         E_q = E_q*E_q*E_q;
-        real *= E_q; imag *= E_q;
+        real /= E_q; imag /= E_q;
     }
 
     // Index into the jones matrices


### PR DESCRIPTION
Previously, when computing the E_pq term for antenna's p and q, it was calculated with the expression E_pq = E_p_E_q, instead of using the hermitian of E_q. E_pq is computed using E_pq = E_p_E_q^H = E_p/E_q.
