### PR TITLE
General rearchitecting of the SharedData object.

### DIFF
--- a/montblanc/BiroSharedData.py
+++ b/montblanc/BiroSharedData.py
@@ -1,0 +1,84 @@
+import numpy as np
+
+from montblanc.BaseSharedData import BaseSharedData
+from montblanc.BaseSharedData import DEFAULT_NA
+from montblanc.BaseSharedData import DEFAULT_NCHAN
+from montblanc.BaseSharedData import DEFAULT_NTIME
+from montblanc.BaseSharedData import DEFAULT_NPSRC
+from montblanc.BaseSharedData import DEFAULT_NGSRC
+from montblanc.BaseSharedData import DEFAULT_DTYPE
+
+class BiroSharedData(BaseSharedData):
+    """ Shared Data implementation for BIRO """
+    def __init__(self, na=DEFAULT_NA, nchan=DEFAULT_NCHAN, ntime=DEFAULT_NTIME,
+        npsrc=DEFAULT_NPSRC, ngsrc=DEFAULT_NGSRC, dtype=DEFAULT_DTYPE, **kwargs):
+        """
+        BiroSharedData Constructor
+
+        Parameters:
+            na : integer
+                Number of antennae.
+            nchan : integer
+                Number of channels.
+            ntime : integer
+                Number of timesteps.
+            npsrc : integer
+                Number of point sources.
+            ngsrc : integer
+                Number of gaussian sources.
+            dtype : np.float32 or np.float64
+                Specify single or double precision arithmetic.
+        Keyword Arguments:
+            device : pycuda.device.Device
+                CUDA device to operate on.
+            store_cpu: boolean
+                if True, store cpu versions of the kernel arrays
+                within the GPUSharedData object.
+        """
+        super(BiroSharedData, self).__init__(na=na, nchan=nchan, ntime=ntime,
+            npsrc=npsrc, ngsrc=ngsrc, dtype=dtype, **kwargs)
+
+        sd = self
+        na, nbl, nchan, ntime = sd.na, sd.nbl, sd.nchan, sd.ntime
+        npsrc, ngsrc, nsrc = sd.npsrc, sd.ngsrc, sd.nsrc
+        ft, ct = sd.ft, sd.ct
+
+        # Curry the register_array function for simplicity
+        def reg(name,shape,dtype):
+            self.register_array(name=name,shape=shape,dtype=dtype,
+                registrant='BaseSharedData', gpu=True, cpu=True,
+                shape_member=True, dtype_member=True)
+
+        def reg_prop(name,dtype,default):
+            self.register_property(name=name,dtype=dtype,
+                default=default,registrant='BaseSharedData', setter=True)
+
+        # Set up gaussian scaling parameters
+        # Derived from https://github.com/ska-sa/meqtrees-timba/blob/master/MeqNodes/src/PSVTensor.cc#L493
+        # and https://github.com/ska-sa/meqtrees-timba/blob/master/MeqNodes/src/PSVTensor.cc#L602
+        fwhm2int = 1.0/np.sqrt(np.log(256))
+        # Note that we don't divide by speed of light here. meqtrees code operates
+        # on frequency, while we're dealing with wavelengths.
+        reg_prop('gauss_scale', ft, fwhm2int*np.sqrt(2)*np.pi)
+        reg_prop('ref_wave', ft, 0.0)
+
+        reg_prop('sigma_sqrd', ft, 1.0)
+        reg_prop('X2', ft, 0.0)
+        reg_prop('beam_width', ft, 65)
+        reg_prop('beam_clip', ft, 1.0881)
+
+        reg(name='uvw', shape=(3,nbl,ntime), dtype=ft)
+        reg(name='ant_pairs', shape=(2,nbl,ntime), dtype=np.int32)
+
+        reg(name='lm', shape=(2,nsrc), dtype=ft)
+        reg(name='brightness', shape=(5,ntime,nsrc), dtype=ft)
+        reg(name='gauss_shape', shape=(3, ngsrc), dtype=ft)
+
+        reg(name='wavelength', shape=(nchan,), dtype=ft)
+        reg(name='point_errors', shape=(2,na,ntime), dtype=ft)
+        reg(name='weight_vector', shape=(4,nbl,nchan,ntime), dtype=ft)
+        reg(name='bayes_data', shape=(4,nbl,nchan,ntime), dtype=ct)
+
+        reg(name='jones', shape=(4,nbl,nchan,ntime,nsrc), dtype=ct)
+        reg(name='vis', shape=(4,nbl,nchan,ntime), dtype=ct)
+        reg(name='chi_sqrd_result', shape=(nbl,nchan,ntime), dtype=ft)

--- a/montblanc/MeasurementSetSharedData.py
+++ b/montblanc/MeasurementSetSharedData.py
@@ -5,10 +5,12 @@ import pycuda.gpuarray as gpuarray
 from pyrap.tables import table
 
 import montblanc
-import montblanc.BaseSharedData as BaseSharedData
-from montblanc.BaseSharedData import GPUSharedData
+import montblanc.BaseSharedData
 
-class MeasurementSetSharedData(GPUSharedData):
+from montblanc.BaseSharedData import get_nr_of_baselines
+from montblanc.BiroSharedData import BiroSharedData
+
+class MeasurementSetSharedData(BiroSharedData):
     ANTENNA_TABLE = "ANTENNA"
     SPECTRAL_WINDOW = "SPECTRAL_WINDOW"
 
@@ -42,7 +44,7 @@ class MeasurementSetSharedData(GPUSharedData):
 
         # Determine the problem dimensions
         na = len(ta.getcol("NAME"))
-        nbl = BaseSharedData.get_nr_of_baselines(na)
+        nbl = get_nr_of_baselines(na)
         nchan = f.size
         ntime = uvw.shape[1] // nbl
 

--- a/montblanc/RimeCPU.py
+++ b/montblanc/RimeCPU.py
@@ -1,0 +1,369 @@
+import numpy as np
+
+def rethrow_attribute_exception(e):
+    raise AttributeError, '%s. The appropriate numpy array has not ' \
+        'been set on the shared data object. You need to set ' \
+        'store_cpu=True on your shared data object ' \
+        'as well as call the transfer_* method for this to work.' % e
+
+def compute_gaussian_shape(sd):
+    """
+    Compute the shape values for the gaussian sources.
+
+    Returns a (nbl, nchan, ntime, ngsrc) matrix of floating point scalars.
+    """
+    try:
+        # OK, try obtain the same results with the fwhm factored out!
+        # u1 = u*em - v*el
+        # v1 = u*el + v*em
+        u1 = (np.outer(sd.uvw_cpu[0], sd.gauss_shape_cpu[1]) - \
+             np.outer(sd.uvw_cpu[1], sd.gauss_shape_cpu[0])) \
+            .reshape(sd.nbl,sd.ntime,sd.ngsrc)
+        v1 = (np.outer(sd.uvw_cpu[0], sd.gauss_shape_cpu[0]) + \
+            np.outer(sd.uvw_cpu[1], sd.gauss_shape_cpu[1])) \
+            .reshape(sd.nbl,sd.ntime,sd.ngsrc)
+
+        # Obvious given the above reshape
+        assert u1.shape == (sd.nbl, sd.ntime, sd.ngsrc)
+        assert v1.shape == (sd.nbl, sd.ntime, sd.ngsrc)
+
+        # Construct the scaling factor, this includes the wavelength/frequency
+        # into the mix.
+        scale_uv = sd.gauss_scale/sd.wavelength_cpu[:,np.newaxis]
+        # Should produce nchan x 1
+        assert scale_uv.shape == (sd.nchan,1)
+
+        # u1 *= R, the ratio of the gaussian axis
+        u1 *= sd.gauss_shape_cpu[2][np.newaxis,np.newaxis,:]
+        # Multiply u1 and v1 by the scaling factor
+        u1 = u1[:,np.newaxis,:,:]*scale_uv[np.newaxis,:,np.newaxis,:]
+        v1 = v1[:,np.newaxis,:,:]*scale_uv[np.newaxis,:,np.newaxis,:]
+
+        return np.exp(-(u1**2 + v1**2))
+
+    except AttributeError as e:
+        rethrow_attribute_exception(e)
+
+def compute_gaussian_shape_with_fwhm(sd):
+    """
+    Compute the shape values for the gaussian sources with fwhm factored in.
+
+    Returns a (nbl, nchan, ntime, ngsrc) matrix of floating point scalars.
+    """
+    try:
+        # 1.0/sqrt(e_l^2 + e_m^2).
+        fwhm_inv = 1.0/np.sqrt(sd.gauss_shape_cpu[0]**2 + sd.gauss_shape_cpu[1]**2)
+        # Vector of ngsrc
+        assert fwhm_inv.shape == (sd.ngsrc,)
+
+        cos_pa = sd.gauss_shape_cpu[1]*fwhm_inv    # em / fwhm
+        sin_pa = sd.gauss_shape_cpu[0]*fwhm_inv    # el / fwhm
+
+        # u1 = u*cos_pa - v*sin_pa
+        # v1 = u*sin_pa + v*cos_pa
+        u1 = (np.outer(sd.uvw_cpu[0],cos_pa) - np.outer(sd.uvw_cpu[1],sin_pa))\
+            .reshape(sd.nbl,sd.ntime,sd.ngsrc)
+        v1 = (np.outer(sd.uvw_cpu[0],sin_pa) + np.outer(sd.uvw_cpu[1],cos_pa))\
+            .reshape(sd.nbl,sd.ntime,sd.ngsrc)
+
+        # Obvious given the above reshape
+        assert u1.shape == (sd.nbl, sd.ntime, sd.ngsrc)
+        assert v1.shape == (sd.nbl, sd.ntime, sd.ngsrc)
+
+        # Construct the scaling factor, this includes the wavelength/frequency
+        # into the mix.
+        scale_uv = sd.gauss_scale/(sd.wavelength_cpu[:,np.newaxis]*fwhm_inv)
+        # Should produce nchan x ngsrc
+        assert scale_uv.shape == (sd.nchan, sd.ngsrc)
+
+        # u1 *= R, the ratio of the gaussian axis
+        u1 *= sd.gauss_shape_cpu[2][np.newaxis,np.newaxis,:]
+        # Multiply u1 and v1 by the scaling factor
+        u1 = u1[:,np.newaxis,:,:]*scale_uv[np.newaxis,:,np.newaxis,:]
+        v1 = v1[:,np.newaxis,:,:]*scale_uv[np.newaxis,:,np.newaxis,:]
+
+        assert u1.shape == (sd.nbl, sd.nchan, sd.ntime, sd.ngsrc)
+        assert v1.shape == (sd.nbl, sd.nchan, sd.ntime, sd.ngsrc)
+
+        return np.exp(-(u1**2 + v1**2))
+
+    except AttributeError as e:
+        rethrow_attribute_exception(e)
+
+def compute_k_jones_scalar(sd):
+    """
+    Computes the scalar K (phase) term of the RIME using numpy.
+
+    Returns a (nbl,nchan,ntime,nsrc) matrix of complex scalars.
+    """
+
+    try:
+        # Repeat the wavelengths along the timesteps for now
+        # dim nchan x ntime. 
+        w = np.repeat(sd.wavelength_cpu,sd.ntime).reshape(sd.nchan, sd.ntime)
+
+        # n = sqrt(1 - l^2 - m^2) - 1. Dim 1 x nbl.
+        n = np.sqrt(1. - sd.lm_cpu[0]**2 - sd.lm_cpu[1]**2) - 1.
+
+        # u*l+v*m+w*n. Outer product creates array of dim nbl x ntime x nsrcs
+        phase = (np.outer(sd.uvw_cpu[0], sd.lm_cpu[0]) + \
+            np.outer(sd.uvw_cpu[1], sd.lm_cpu[1]) + \
+            np.outer(sd.uvw_cpu[2],n))\
+                .reshape(sd.nbl, sd.ntime, sd.nsrc)
+        assert phase.shape == (sd.nbl, sd.ntime, sd.nsrc)            
+
+        # 2*pi*sqrt(u*l+v*m+w*n)/wavelength. Dim. nbl x nchan x ntime x nsrcs 
+        phase = (2*np.pi*1j*phase)[:,np.newaxis,:,:]/w[np.newaxis,:,:,np.newaxis]
+        assert phase.shape == (sd.nbl, sd.nchan, sd.ntime, sd.nsrc)            
+
+        # Dim nchan x ntime x nsrcs 
+        power = np.power(sd.ref_wave/w[:,:,np.newaxis],
+            sd.brightness_cpu[4,np.newaxis,:,:])
+        assert power.shape == (sd.nchan, sd.ntime, sd.nsrc)            
+
+        # This works due to broadcast! Dim nbl x nchan x ntime x nsrcs
+        phase_term = power*np.exp(phase)
+        assert phase_term.shape == (sd.nbl, sd.nchan, sd.ntime, sd.nsrc)            
+
+        # Multiply the gaussian sources by their shape terms.
+        if sd.ngsrc > 0:
+            phase_term[:,:,:,sd.npsrc:sd.nsrc] *= compute_gaussian_shape(sd)
+
+        return phase_term
+
+    except AttributeError as e:
+        rethrow_attribute_exception(e)
+
+def compute_per_ant_e_jones_scalar(sd):
+    """
+    Computes the scalar E (analytic cos^3) term of the RIME per antenna.
+
+    returns a (na,nchan,ntime,nsrc) matrix of complex scalars.
+    """
+
+    try:
+        # Compute the offsets for different antenna
+        # Broadcasting here produces, na x ntime x nsrc
+        l_off = sd.lm_cpu[0] - sd.point_errors_cpu[0,:,:,np.newaxis]
+        m_off = sd.lm_cpu[1] - sd.point_errors_cpu[1,:,:,np.newaxis]
+        E_p = np.sqrt(l_off**2 + m_off**2)
+
+        assert E_p.shape == (sd.na, sd.ntime, sd.nsrc)
+
+        # Broadcasting here produces, nbl x nchan x ntime x nsrc
+        E_p = sd.beam_width*1e-9*E_p[:,np.newaxis,:,:] *\
+            sd.wavelength_cpu[np.newaxis,:,np.newaxis,np.newaxis]
+        np.clip(E_p, np.finfo(sd.ft).min, sd.beam_clip, E_p)
+        E_p = np.cos(E_p)**3
+
+        assert E_p.shape == (sd.na, sd.nchan, sd.ntime, sd.nsrc)
+
+        return E_p
+    except AttributeError as e:
+        rethrow_attribute_exception(e)
+
+def compute_e_jones_scalar(sd):
+    """
+    Computes the scalar E (analytic cos^3) term of the RIME
+
+    returns a (nbl,nchan,ntime,nsrc) matrix of complex scalars.
+    """
+    try:
+        # Here we obtain our antenna pairs and pointing errors
+        # TODO: The last dimensions are flattened to make indexing easier
+        # later. There may be a more numpy way to do this but YOLO.
+        ap = sd.get_default_ant_pairs().reshape(2,sd.nbl*sd.ntime)
+        pe = sd.point_errors_cpu.reshape(2,sd.na*sd.ntime)
+
+        # The flattened antenna pair array will look something like this.
+        # It is based on 2 x nbl x ntime. Here we have 3 baselines and
+        # 4 timesteps.
+        #
+        #            timestep
+        #       0 1 2 3 0 1 2 3 0 1 2 3
+        #
+        # ant0: 0 0 0 0 0 0 0 0 1 1 1 1
+        # ant1: 1 1 1 1 2 2 2 2 2 2 2 2
+
+        # Create indexes into the pointing errors from the antenna pairs.
+        # Pointing errors is 2 x na x ntime, thus each index will be
+        # i = ANT*ntime + TIME. The TIME additions need to be padded by nbl.
+        ant0 = ap[0]*sd.ntime + np.tile(np.arange(sd.ntime), sd.nbl)
+        ant1 = ap[1]*sd.ntime + np.tile(np.arange(sd.ntime), sd.nbl)
+
+        # Get the pointing errors for antenna p and q.
+        d_p = pe[:,ant0].reshape(2,sd.nbl,sd.ntime)
+        d_q = pe[:,ant1].reshape(2,sd.nbl,sd.ntime)
+
+        # Compute the offsets for antenna 0 or p
+        # Broadcasting here produces, nbl x ntime x nsrc
+        l_off = sd.lm_cpu[0] - d_p[0,:,:,np.newaxis]
+        m_off = sd.lm_cpu[1] - d_p[1,:,:,np.newaxis]
+        E_p = np.sqrt(l_off**2 + m_off**2)
+
+        assert E_p.shape == (sd.nbl, sd.ntime, sd.nsrc)
+
+        # Broadcasting here produces, nbl x nchan x ntime x nsrc
+        E_p = sd.beam_width*1e-9*E_p[:,np.newaxis,:,:]*\
+            sd.wavelength_cpu[np.newaxis,:,np.newaxis,np.newaxis]
+        np.clip(E_p, np.finfo(sd.ft).min, sd.beam_clip, E_p)
+        E_p = np.cos(E_p)**3
+
+        assert E_p.shape == (sd.nbl, sd.nchan, sd.ntime, sd.nsrc)
+
+        # Compute the offsets for antenna 1 or q
+        # Broadcasting here produces, nbl x ntime x nsrc
+        l_off = sd.lm_cpu[0] - d_q[0,:,:,np.newaxis]
+        m_off = sd.lm_cpu[1] - d_q[1,:,:,np.newaxis]
+        E_q = np.sqrt(l_off**2 + m_off**2)
+
+        assert E_q.shape == (sd.nbl, sd.ntime, sd.nsrc)
+
+        # Broadcasting here produces, nbl x nchan x ntime x nsrc
+        E_q = sd.beam_width*1e-9*E_q[:,np.newaxis,:,:]*\
+            sd.wavelength_cpu[np.newaxis,:,np.newaxis,np.newaxis]
+        np.clip(E_q, np.finfo(sd.ft).min, sd.beam_clip, E_q)
+        E_q = np.cos(E_q)**3
+
+        assert E_q.shape == (sd.nbl, sd.nchan, sd.ntime, sd.nsrc)
+
+        return E_p/E_q
+    except AttributeError as e:
+        rethrow_attribute_exception(e)
+
+def compute_ek_jones_scalar(sd):
+    """
+    Computes the scalar EK (phase*cos^3) term of the RIME.
+
+    Return a (nbl,nchan,ntime,nsrc) matrix of complex scalars.
+    """
+    return compute_k_jones_scalar(sd)*compute_e_jones_scalar(sd)
+
+def compute_b_jones(sd):
+    """
+    Computes the B term of the RIME.
+
+    Returns a (4,nsrc) matrix of complex scalars.
+    """
+    try:
+        # Create the brightness matrix. Dim 4 x ntime x nsrcs
+        B = sd.ct([
+            sd.brightness_cpu[0]+sd.brightness_cpu[1] + 0j,     # fI+fQ + 0j
+            sd.brightness_cpu[2] + 1j*sd.brightness_cpu[3],     # fU + fV*1j
+            sd.brightness_cpu[2] - 1j*sd.brightness_cpu[3],     # fU - fV*1j
+            sd.brightness_cpu[0]-sd.brightness_cpu[1] + 0j])    # fI-fQ + 0j
+        assert B.shape == (4, sd.ntime, sd.nsrc)
+
+        return B
+
+    except AttributeError as e:
+        rethrow_attribute_exception(e)
+
+def compute_bk_jones(sd):
+    """
+    Computes the BK term of the RIME.
+
+    Returns a (4,nbl,nchan,ntime,nsrc) matrix of complex scalars.
+    """
+
+    # Compute the K and B terms
+    scalar_K = compute_k_jones_scalar(sd)
+    B = compute_b_jones(sd)
+
+    # This works due to broadcast! Multiplies phase and brightness along
+    # srcs axis of brightness. Dim 4 x nbl x nchan x ntime x nsrcs.
+    jones_cpu = (scalar_K[np.newaxis,:,:,:,:]* \
+        B[:,np.newaxis, np.newaxis,:,:])#\
+        #.reshape((4, sd.nbl, sd.nchan, sd.ntime, sd.nsrc))
+    assert jones_cpu.shape == sd.jones_shape
+
+    return jones_cpu 
+
+def compute_ebk_jones(sd):
+    """
+    Computes the BK term of the RIME.
+
+    Returns a (4,nbl,nchan,ntime,nsrc) matrix of complex scalars.
+    """
+    return compute_bk_jones(sd)*compute_e_jones_scalar(sd)
+
+def compute_bk_vis(sd):
+    """
+    Computes the complex visibilities based on the
+    scalar K term and the 2x2 B term.
+
+    Returns a (4,nbl,nchan,ntime) matrix of complex scalars.
+    """
+    return np.add.reduce(compute_bk_jones(sd), axis=4)        
+
+def compute_ebk_vis(sd):
+    """
+    Computes the complex visibilities based on the
+    scalar EK term and the 2x2 B term.
+
+    Returns a (4,nbl,nchan,ntime) matrix of complex scalars.
+    """
+    return np.add.reduce(compute_ebk_jones(sd), axis=4)        
+
+def compute_chi_sqrd_sum_terms(sd, weight_vector=False):
+    """
+    Computes the terms of the chi squared sum, but does not perform the sum itself.
+
+    Parameters:
+        weight_vector : boolean
+            True if the chi squared test terms should be computed with a noise vector
+
+    Returns a (nbl,nchan,ntime) matrix of floating point scalars.
+    """
+
+    try:
+        # Take the difference between the visibilities and the model
+        # (4,nbl,nchan,ntime)
+        d = sd.vis_cpu - sd.bayes_data_cpu
+
+        # Square of the real and imaginary components
+        real_term, imag_term = d.real**2, d.imag**2
+
+        # Multiply by the weight vector if required
+        if weight_vector is True:
+            real_term *= sd.weight_vector_cpu
+            imag_term *= sd.weight_vector_cpu
+
+        # Reduces a dimension so that we have (nbl,nchan,ntime)
+        # (XX.real^2 + XY.real^2 + YX.real^2 + YY.real^2) + 
+        # ((XX.imag^2 + XY.imag^2 + YX.imag^2 + YY.imag^2))
+
+        # Sum the real and imaginary terms together
+        # for the final result.
+        chi_sqrd_terms = np.add.reduce(real_term,axis=0) + np.add.reduce(imag_term,axis=0)
+
+        assert chi_sqrd_terms.shape == (sd.nbl, sd.nchan, sd.ntime)
+
+        return chi_sqrd_terms
+
+    except AttributeError as e:
+        rethrow_attribute_exception(e)
+
+def compute_chi_sqrd(sd, weight_vector=False):
+    """ Computes the chi squared value.
+
+    Parameters:
+        weight_vector : boolean
+            True if the chi squared test should be computed with a noise vector
+
+    Returns a floating point scalar values
+    """
+
+    # Do the chi squared sum on the CPU.
+    # If we're not using the weight vector, sum and
+    # divide by the sigma squared.
+    # Otherwise, simply return the sum
+    try:
+        term_sum = compute_chi_sqrd_sum_terms(sd, weight_vector=weight_vector).sum()
+        return term_sum if weight_vector is True else term_sum / sd.sigma_sqrd
+    except AttributeError as e:
+        rethrow_attribute_exception(e)
+
+def compute_biro_chi_sqrd(sd, weight_vector=False):
+    sd.vis_cpu = compute_ebk_vis(sd)
+    return compute_chi_sqrd(sd, weight_vector=weight_vector)

--- a/montblanc/RimeEBK.py
+++ b/montblanc/RimeEBK.py
@@ -374,12 +374,12 @@ class RimeEBK(Node):
             # Note the null pointer passed for gauss_shape here.
             self.kernel(sd.uvw_gpu, sd.lm_gpu, sd.brightness_gpu, np.intp(0),
                 sd.wavelength_gpu, sd.point_errors_gpu, sd.ant_pairs_gpu, sd.jones_gpu,
-                sd.ref_wave, sd.beam_width, sd.E_beam_clip,
+                sd.ref_wave, sd.beam_width, sd.beam_clip,
     			**self.get_kernel_params(sd))
         elif self.gaussian and sd.ngsrc > 0:
             self.kernel(sd.uvw_gpu, sd.lm_gpu, sd.brightness_gpu, sd.gauss_shape_gpu,
                 sd.wavelength_gpu, sd.point_errors_gpu, sd.ant_pairs_gpu, sd.jones_gpu,
-                sd.ref_wave, sd.beam_width, sd.E_beam_clip,
+                sd.ref_wave, sd.beam_width, sd.beam_clip,
                 **self.get_kernel_params(sd))
 
     def post_execution(self, shared_data):

--- a/montblanc/__init__.py
+++ b/montblanc/__init__.py
@@ -11,7 +11,7 @@ import montblanc
 
 from montblanc.node import Node, NullNode
 from montblanc.pipeline import Pipeline
-from montblanc.BaseSharedData import GPUSharedData
+from montblanc.BaseSharedData import BaseSharedData
 
 from montblanc.RimeBK import RimeBK
 from montblanc.RimeEBK import RimeEBK


### PR DESCRIPTION
The SharedData object is responsible for defining the problem dimensions and parameters. Additionally, it stores a number of gpuarrays and ndarrays, or, the data used to solve the RIME on the GPU and CPU respectively.

Since GPU code is not easy to modify or abstract, we need the ability to flexibly support different arrays for different problems, instead of blindly hardcoding all the arrays for each problem into the SharedData object. Such an approach is wasteful in terms of GPU memory.

To this end, we will use Python's ability to dynamically modify SharedData object instances at runtime. Users of the SharedData object are now presented with the ability to register CPU and GPU arrays on the SharedData object. This dynamically adds the arrays, as well as any methods and members required to interact with them. Other previously hardcoded SharedData members, such as beam width and reference wavelength, are registered as properties on SharedData objects.
