### PR TITLE
Reordered version two BIRO arrays to adhere to a ntime x nbl ordering and other changes to get version two to produce correct results

### DIFF
--- a/montblanc/__init__.py
+++ b/montblanc/__init__.py
@@ -9,6 +9,13 @@ import os
 # Hooray for python
 import montblanc
 
+def nr_of_baselines(na, auto_correlations=False):
+    """ Compute the number of baselines for the 
+    given number of antenna. Can specify whether
+    auto-correlations should be taken into
+    account """
+    return (na*(na-1))//2 if auto_correlations is False else (na*(na+1)/2)
+
 def get_montblanc_path():
 	""" Return the current path in which montblanc is installed """
 	return os.path.dirname(inspect.getfile(montblanc))

--- a/montblanc/impl/biro/v1/BiroSharedData.py
+++ b/montblanc/impl/biro/v1/BiroSharedData.py
@@ -35,6 +35,10 @@ class BiroSharedData(BaseSharedData):
                 if True, store cpu versions of the kernel arrays
                 within the GPUSharedData object.
         """
+
+        # Turn off auto_correlations
+        kwargs['auto_correlations'] = False
+
         super(BiroSharedData, self).__init__(na=na, nchan=nchan, ntime=ntime,
             npsrc=npsrc, ngsrc=ngsrc, dtype=dtype, **kwargs)
 
@@ -84,7 +88,7 @@ class BiroSharedData(BaseSharedData):
         reg(name='chi_sqrd_result', shape=('nbl','nchan','ntime'), dtype=ft)
 
         # Get the numeric jones shape, so that we can calculate the key array size
-        njones_shape = self.get_array_record('jones').nshape
+        njones_shape = self.get_array_record('jones').shape
 
         # Create the key positions. This snippet creates an array
         # equal to the list of positions of the last array element timestep)
@@ -94,3 +98,15 @@ class BiroSharedData(BaseSharedData):
         reg(name='keys', shape=keys.shape, dtype=np.int32)
 
         sd.transfer_keys(keys)
+
+    def get_default_ant_pairs(self):
+        """
+        Return an np.array(shape=(2, nbl, ntime), dtype=np.int32]) containing the
+        default antenna pairs for each baseline at each timestep.
+        """
+        # Create the antenna pair mapping, from upper triangle indices
+        # based on the number of antenna. 
+        sd = self
+
+        return np.repeat(np.int32(np.triu_indices(sd.na,1)),
+            sd.ntime).reshape(2,sd.nbl,sd.ntime)

--- a/montblanc/impl/biro/v1/TestSharedData.py
+++ b/montblanc/impl/biro/v1/TestSharedData.py
@@ -16,6 +16,7 @@ class TestSharedData(BiroSharedData):
     def __init__(self, na=DEFAULT_NA, nchan=DEFAULT_NCHAN, ntime=DEFAULT_NTIME,
         npsrc=DEFAULT_NPSRC, ngsrc=0, dtype=np.float32, **kwargs):
 
+        # Store CPU arrays
         kwargs['store_cpu'] = True
 
         super(TestSharedData, self).__init__(na=na, nchan=nchan, ntime=ntime,

--- a/montblanc/impl/biro/v1/cpu/RimeCPU.py
+++ b/montblanc/impl/biro/v1/cpu/RimeCPU.py
@@ -25,6 +25,7 @@ class RimeCPU(object):
             w = sd.uvw_cpu[2]
             el = sd.gauss_shape_cpu[0]
             em = sd.gauss_shape_cpu[1]
+            R = sd.gauss_shape_cpu[2]
 
             # OK, try obtain the same results with the fwhm factored out!
             # u1 = u*em - v*el
@@ -48,7 +49,7 @@ class RimeCPU(object):
             u1 = u1[:,np.newaxis,:,:]*scale_uv[np.newaxis,:,np.newaxis,np.newaxis]
             v1 = v1[:,np.newaxis,:,:]*scale_uv[np.newaxis,:,np.newaxis,np.newaxis]
             # u1 *= R, the ratio of the gaussian axis
-            u1 *= sd.gauss_shape_cpu[2][np.newaxis,np.newaxis,np.newaxis,:]
+            u1 *= R[np.newaxis,np.newaxis,np.newaxis,:]
 
             return np.exp(-(u1**2 + v1**2))
 

--- a/montblanc/impl/biro/v2/MeasurementSetSharedData.py
+++ b/montblanc/impl/biro/v2/MeasurementSetSharedData.py
@@ -7,7 +7,6 @@ from pyrap.tables import table
 import montblanc
 import montblanc.BaseSharedData
 
-from montblanc.BaseSharedData import get_nr_of_baselines
 from montblanc.impl.biro.v2.BiroSharedData import BiroSharedData
 
 class MeasurementSetSharedData(BiroSharedData):
@@ -26,12 +25,7 @@ class MeasurementSetSharedData(BiroSharedData):
         self.msfile = msfile
 
         # Open the measurement set
-        ms = table(self.msfile, ack=False)
-        # Strip out all auto-correlated baselines
-        t = ms.query('ANTENNA1 != ANTENNA2')
-
-        # Get the UVW coordinates
-        uvw=t.getcol("UVW").T.astype(dtype)
+        t = table(self.msfile, ack=False).query('ANTENNA1 != ANTENNA2')
 
         # Open the antenna table
         ant_path = os.path.join(self.msfile, MeasurementSetSharedData.ANTENNA_TABLE)
@@ -42,11 +36,14 @@ class MeasurementSetSharedData(BiroSharedData):
         tf=table(freq_path, ack=False)
         f=tf.getcol("CHAN_FREQ").astype(dtype)
 
+        # Turn on auto_correlations
+        kwargs['auto_correlations'] = False
+
         # Determine the problem dimensions
-        na = len(ta.getcol("NAME"))
-        nbl = get_nr_of_baselines(na)
+        na = ta.nrows()
+        nbl = montblanc.nr_of_baselines(na, kwargs['auto_correlations'])
         nchan = f.size
-        ntime = uvw.shape[1] // nbl
+        ntime = t.nrows() // nbl
 
         super(MeasurementSetSharedData, self).__init__(\
             na=na,nchan=nchan,ntime=ntime,npsrc=npsrc,ngsrc=ngsrc,dtype=dtype,**kwargs)
@@ -55,36 +52,52 @@ class MeasurementSetSharedData(BiroSharedData):
         assert nbl == self.nbl
 
         # Check that we're getting the correct shape...
-        expected_uvw_shape = (3, nbl*ntime)
+        uvw_shape = (ntime*nbl, 3)
 
-        if expected_uvw_shape != uvw.shape:
-            raise ValueError, 'uvw.shape %s != expected %s' % (uvw.shape,expected_uvw_shape)
-
-        # Reshape the flattened array, and then only use the na baselines
-        # of the uvw array at each timestep. The remaining baselines will be
-        # calculated by linear combination. u_pq = u_p - u_q.
-        ant_uvw = uvw.reshape(3,nbl,ntime)[:,0:na,:]
-		# Normalise relative to antenna 0
-        ant_uvw = ant_uvw - ant_uvw[:,0,np.newaxis,:]
+        # Read in UVW
+        # Reshape the array and correct the axes
+        ms_uvw = t.getcol('UVW')
+        assert ms_uvw.shape == uvw_shape, \
+            'MS UVW shape %s != expected %s' % (ms_uvw.shape,expected_uvw_shape)
+        uvw_rec = self.get_array_record('uvw')
+        uvw=np.empty(shape=uvw_rec.shape, dtype=uvw_rec.dtype)
+        uvw[:,:,1:na] = ms_uvw.reshape(ntime, nbl, 3).transpose(2,0,1) \
+            .astype(self.ft)[:,:,:na-1]
+        uvw[:,:,0] = self.ft(0)
+        self.transfer_uvw(np.ascontiguousarray(uvw))
 
         # Determine the wavelengths
         wavelength = (montblanc.constants.C/f[0]).astype(self.ft)
+        self.transfer_wavelength(wavelength)
 
-        # Get the baseline antenna pairs
-        ant1 = t.getcol('ANTENNA1')
-        ant2 = t.getcol('ANTENNA2')
+        # First dimension also seems to be of size 1 here...
+        # Divide speed of light by frequency to get the wavelength here.
+        self.set_ref_wave(montblanc.constants.C/tf.getcol('REF_FREQUENCY')[0])
+
+        # Get the baseline antenna pairs and correct the axes
+        ant1 = t.getcol('ANTENNA1').reshape(ntime,nbl)
+        ant2 = t.getcol('ANTENNA2').reshape(ntime,nbl)
+
+        expected_ant_shape = (ntime,nbl)
+        
+        assert expected_ant_shape == ant1.shape, \
+            'ANTENNA1 shape is %s != expected %s' % (ant1.shape,expected_ant_shape)
+
+        assert expected_ant_shape == ant2.shape, \
+            'ANTENNA2 shape is %s != expected %s' % (ant2.shape,expected_ant_shape)
+
+        ant_pairs = np.vstack((ant1,ant2)).reshape(self.ant_pairs_shape)
+
+        # Transfer the uvw coordinates, antenna pairs and wavelengths to the GPU
+        self.transfer_ant_pairs(np.ascontiguousarray(ant_pairs))
 
         # Load in visibility data, if it exists.
         if t.colnames().count('DATA') > 0:
             # Obtain visibilities stored in the DATA column
-            # This comes in as (nbl*ntime,nchan,4)
-            vis_data = t.getcol('DATA')
-
-            # Shift the dim 4 axis to the front,
-            # reshape to separate nbl and ntime
-            vis_data = np.rollaxis(vis_data,axis=2,start=0) \
-                .reshape(4,nbl,ntime,nchan).astype(self.ct).copy()
-            self.transfer_bayes_data(vis_data)
+            # This comes in as (ntime*nbl,nchan,4)
+            vis_data = t.getcol('DATA').reshape(ntime,nbl,nchan,4) \
+                .transpose(3,0,1,2).astype(self.ct)
+            self.transfer_bayes_data(np.ascontiguousarray(vis_data))
 
         # Should we initialise our weights from the MS data?
         init_weights = kwargs.get('init_weights', None)
@@ -109,11 +122,11 @@ class MeasurementSetSharedData(BiroSharedData):
                 # Obtain weighting information from WEIGHT_SPECTRUM
                 # preferably, otherwise WEIGHT.
                 if t.colnames().count('WEIGHT_SPECTRUM') > 0:
-                    # Try obtain the weightings from 'WEIGHT_SPECTRUM' first.
+                    # Try obtain the weightings from WEIGHT_SPECTRUM first.
                     # It has the same dimensions as 'FLAG'
                     weight_vector = flag*t.getcol('WEIGHT_SPECTRUM')
                 elif t.colnames().count('WEIGHT') > 0:
-                    # Otherwise we should try obtain the weightings from 'WEIGHT.
+                    # Otherwise we should try obtain the weightings from WEIGHT.
                     # This doesn't have per-channel weighting, so we introduce
                     # this with a broadcast
                     weight_vector = flag * \
@@ -125,11 +138,11 @@ class MeasurementSetSharedData(BiroSharedData):
                 # Obtain weighting information from SIGMA_SPECTRUM
                 # preferably, otherwise SIGMA.
                 if t.colnames().count('SIGMA_SPECTRUM') > 0:
-                    # Try obtain the weightings from 'WEIGHT_SPECTRUM' first.
+                    # Try obtain the weightings from WEIGHT_SPECTRUM first.
                     # It has the same dimensions as 'FLAG'
                     weight_vector = flag*t.getcol('SIGMA_SPECTRUM')
                 elif t.colnames().count('SIGMA') > 0:
-                    # Otherwise we should try obtain the weightings from 'WEIGHT.
+                    # Otherwise we should try obtain the weightings from WEIGHT.
                     # This doesn't have per-channel weighting, so we introduce
                     # this with a broadcast
                     weight_vector = flag * \
@@ -140,34 +153,64 @@ class MeasurementSetSharedData(BiroSharedData):
             else:
                 raise Exception, 'init_weights used incorrectly!'
 
-            assert weight_vector.shape == (nbl*ntime, nchan, 4)
+            assert weight_vector.shape == (ntime*nbl, nchan, 4)
 
-            # Shift the dim 4 axis to the front,
-            # reshape to separate nbl and ntime
-            weight_vector=np.rollaxis(weight_vector,axis=2,start=0) \
-                .reshape(4,nbl,ntime,nchan)
+            weight_vector = weight_vector.reshape(ntime,nbl,nchan,4) \
+                .transpose(3,0,1,2).astype(self.ft)
 
-            self.transfer_weight_vector(weight_vector)
+            self.transfer_weight_vector(np.ascontiguousarray(weight_vector))
 
-        expected_ant_shape = (nbl*ntime,)
-        
-        if expected_ant_shape != ant1.shape:
-            raise ValueError, 'ANTENNA1 shape is %s != expected %s' % (ant1.shape,expected_ant_shape)
-
-        if expected_ant_shape != ant2.shape:
-            raise ValueError, 'ANTENNA2 shape is %s != expected %s' % (ant2.shape,expected_ant_shape)
-
-        ant_pairs = np.vstack((ant1,ant2)).reshape(self.ant_pairs_shape)
-
-        # Transfer the uvw coordinates, antenna pairs and wavelengths to the GPU
-        self.transfer_uvw(ant_uvw.copy())
-        self.transfer_ant_pairs(ant_pairs)
-        self.transfer_wavelength(wavelength)
-
-        # First dimension also seems to be of size 1 here...
-        # Divide speed of light by frequency to get the wavelength here.
-        self.set_ref_wave(montblanc.constants.C/tf.getcol('REF_FREQUENCY')[0])
+        #self.test_uvw_relations(ms_uvw, ant_pairs)
 
         t.close()
         ta.close()
         tf.close()
+
+    def test_uvw_relations(self, msuvw, ant_pairs):
+        """ Test that the uvw relation holds """
+        ap = ant_pairs.reshape(2,self.ntime*self.nbl)
+
+        # Create 1D indices from the flattened antenna pair array.
+        # Multiply it by size constant and add tiling corresponding
+        # to the indexing.
+        ant0 = ap[0] + np.repeat(np.arange(self.ntime),self.nbl)*self.na
+        ant1 = ap[1] + np.repeat(np.arange(self.ntime),self.nbl)*self.na
+
+        uvw_rec = self.get_array_record('uvw')
+        uvw=np.empty(shape=uvw_rec.shape, dtype=uvw_rec.dtype)
+        uvw[:,:,1:self.na] = msuvw.reshape(self.ntime, self.nbl, 3).transpose(2,0,1) \
+            .astype(self.ft)[:,:,:self.na-1]
+        uvw[:,:,0] = self.ft(0)
+
+        print 'uvw', uvw
+        print 'uvw diff', uvw[:,:,:] - uvw[:,:,:]
+
+        """
+        ap = ant_pairs.reshape(2,self.ntime*self.nbl)
+
+        # Create 1D indices from the flattened antenna pair array.
+        # Multiply it by size constant and add tiling corresponding
+        # to the indexing.
+        ant0 = ap[0] + np.repeat(np.arange(self.ntime),self.nbl)*self.na
+        ant1 = ap[1] + np.repeat(np.arange(self.ntime),self.nbl)*self.na
+
+        print uvw.shape
+        print 'ant0 == ant1 %s' % (ant0 == ant1).all()
+
+
+        np.savetxt('file.txt',(uvw[:,:] - (uvw[ant1,:] - uvw[ant0,:])))
+
+        idx = np.empty(shape=(self.ntime*self.nbl),dtype=np.int32)
+
+        suvw = uvw.reshape(self.ntime,self.nbl,3)
+
+        # TODO. Inefficient indexing. Figure something out based
+        # on RimeCPU.compute_gaussian_shape
+        for t in range(self.ntime):
+            for bl in range(self.nbl):
+                #idx[t*self.nbl + bl] = t*self.na + ant_pairs[0,t,bl]
+                assert np.allclose(
+                    suvw[t,bl,:],
+                    suvw[t,ant_pairs[1,t,bl],:] - suvw[t,ant_pairs[0,t,bl],:]), \
+                    'UVW Relation does not hold for timestep %d baseline %d!' % (t,bl)
+        """

--- a/montblanc/impl/biro/v2/TestSharedData.py
+++ b/montblanc/impl/biro/v2/TestSharedData.py
@@ -16,6 +16,7 @@ class TestSharedData(BiroSharedData):
     def __init__(self, na=DEFAULT_NA, nchan=DEFAULT_NCHAN, ntime=DEFAULT_NTIME,
         npsrc=DEFAULT_NPSRC, ngsrc=0, dtype=np.float32, **kwargs):
 
+        # Store CPU arrays
         kwargs['store_cpu'] = True
 
         super(TestSharedData, self).__init__(na=na, nchan=nchan, ntime=ntime,
@@ -39,12 +40,13 @@ class TestSharedData(BiroSharedData):
         uvw = shape_list([3.*r, 2.*r, 1.*r],
             shape=sd.uvw_shape, dtype=sd.uvw_dtype)
 
-		# Normalise UVW coordinates relative to antenna 0
-        uvw = uvw - uvw[:,0,np.newaxis,:]
+		# Normalise Antenna 0
+        uvw[:,:,0] = 0
 
         # Point source coordinates in the l,m,n (sky image) domain
-        l=ft(np.random.random(nsrc)*0.1)
-        m=ft(np.random.random(nsrc)*0.1)
+        # 1e-4 ~ 20 arcseconds
+        l=ft(np.random.random(nsrc)*1e-4)
+        m=ft(np.random.random(nsrc)*1e-4)
         lm=shape_list([l,m], sd.lm_shape, sd.lm_dtype)
 
         # Brightness matrix for the point sources

--- a/montblanc/tests/run_tests.sh
+++ b/montblanc/tests/run_tests.sh
@@ -1,0 +1,3 @@
+for test in test*.py; do
+	python $test
+done

--- a/montblanc/tests/test_biro_v1.py
+++ b/montblanc/tests/test_biro_v1.py
@@ -76,6 +76,8 @@ class TestBiroV1(unittest.TestCase):
         """ Type independent implementation of the EBK test """
         if cmp is None: cmp = {}
 
+        # This beam width produces reasonable values
+        # for testing the E term
         sd.set_beam_width(65*1e5)
 
         kernels = []


### PR DESCRIPTION
Version two of the BIRO pipeline initially assumed that the ordering of Measurement Set rows was nbl x ntime when, in practice, it is ntime x nbl. This change reorders the numpy arrays, GPU kernels and numpy CPU code to take this into account. It also:
- Correctly loads in per antenna UVW coordinates from the MS.
- Uses multiplication by complex conjugate when combining per antenna terms. In practice this means that the phase term Kpq for baseline pq is calculated by Kpq = Kp_Kq.conj(), instead of Kpq = Kp/Kq. Similarly the beam term Epq = Ep_Eq.conj() = Ep*Eq since it is a real scalar.
- Removed the (wavelength_ref/wavelength)^alpha power term out of the per antenna Kp terms. It is now only incorporated into the per baseline Kpq terms.
- Fixed race conditions in the RimeGaussBsum kernel.
- Made the numpy CPU code more flexible. There are now functions for computing K, E and EK terms per antenna and per baseline.
- Added code for computing BK jones matrices, as well as BK visibilities in the numpy code, even though the GPU code does not explicitly compute this. This code is used to compare against Cyril's predict code.
- Improved variable names throughout the numpy CPU code for readability. e.g. l, m = lm_cpu[0], lm_cpu[1].
- Removed unnecessary imports.
- Added the ability to specify whether auto-correlations should be included when calculating the number of baselines.

Test Cases
- Removed multiplication test cases
- Added test case comparing v2 CPU BK computation (no beam term) against Cyril's predict.
