### PR TITLE
Cater for different timestep/baseline MeasurementSet orderings 

### DIFF
--- a/montblanc/__init__.py
+++ b/montblanc/__init__.py
@@ -63,6 +63,12 @@ def get_biro_solver(msfile, npsrc, ngsrc, nssrc, dtype=np.float32, **kwargs):
 
     Keyword Arguments
     -----------------
+    data_order : string
+	    Indicates what is the MeasurementSet data ordering: time x baseline or baseline x time.
+	    None - Assume Montblanc's default ordering (time x baseline)
+	    'casa' - Assume CASA's default ordering. It matches Montblanc's default ordering, so it can be avoided.
+	    'other' - Assume baseline x time ordering
+    
     init_weights : string
             Indicates how the weight vector should be initialised from the Measurementset.
             None - Don't initialise the weight vector.

--- a/montblanc/factory.py
+++ b/montblanc/factory.py
@@ -149,8 +149,8 @@ def create_biro_solver_from_ms(slvr_class_type, **kwargs):
 
     with MeasurementSetLoader(kwargs.get('msfile')) as loader:
         ntime,na,nchan = loader.get_dims()
-	slvr = slvr_class_type(na=na,ntime=ntime,nchan=nchan,**kwargs)
-	loader.load(slvr, **kwargs)
+        slvr = slvr_class_type(na=na,ntime=ntime,nchan=nchan,**kwargs)
+        loader.load(slvr, **kwargs)
         return slvr
 
 def create_biro_solver_from_test_data(slvr_class_type, **kwargs):

--- a/montblanc/factory.py
+++ b/montblanc/factory.py
@@ -150,7 +150,8 @@ def create_biro_solver_from_ms(slvr_class_type, **kwargs):
     with MeasurementSetLoader(kwargs.get('msfile')) as loader:
         ntime,na,nchan = loader.get_dims()
         slvr = slvr_class_type(na=na,ntime=ntime,nchan=nchan,**kwargs)
-        loader.load(slvr)
+        kwargs['uvw_order']=kwargs.get('uvw_order')
+	loader.load(slvr, **kwargs)
         return slvr
 
 def create_biro_solver_from_test_data(slvr_class_type, **kwargs):

--- a/montblanc/factory.py
+++ b/montblanc/factory.py
@@ -150,7 +150,6 @@ def create_biro_solver_from_ms(slvr_class_type, **kwargs):
     with MeasurementSetLoader(kwargs.get('msfile')) as loader:
         ntime,na,nchan = loader.get_dims()
         slvr = slvr_class_type(na=na,ntime=ntime,nchan=nchan,**kwargs)
-        kwargs['uvw_order']=kwargs.get('uvw_order')
 	loader.load(slvr, **kwargs)
         return slvr
 

--- a/montblanc/factory.py
+++ b/montblanc/factory.py
@@ -149,7 +149,7 @@ def create_biro_solver_from_ms(slvr_class_type, **kwargs):
 
     with MeasurementSetLoader(kwargs.get('msfile')) as loader:
         ntime,na,nchan = loader.get_dims()
-        slvr = slvr_class_type(na=na,ntime=ntime,nchan=nchan,**kwargs)
+	slvr = slvr_class_type(na=na,ntime=ntime,nchan=nchan,**kwargs)
 	loader.load(slvr, **kwargs)
         return slvr
 

--- a/montblanc/impl/biro/v2/cpu/SolverCPU.py
+++ b/montblanc/impl/biro/v2/cpu/SolverCPU.py
@@ -373,8 +373,7 @@ class SolverCPU(object):
 
         slvr = self.solver
 
-	vis = ne.evaluate('sum(ebk,3)', {'ebk': self.compute_ebk_jones()}).squeeze()\
-            .astype(slvr.ct)
+	vis = ne.evaluate('sum(ebk,3)', {'ebk': self.compute_ebk_jones()}).squeeze(axis=(3,)).astype(slvr.ct)
         assert vis.shape == (4, slvr.ntime, slvr.nbl, slvr.nchan)
 
         return vis

--- a/montblanc/impl/biro/v2/cpu/SolverCPU.py
+++ b/montblanc/impl/biro/v2/cpu/SolverCPU.py
@@ -373,7 +373,16 @@ class SolverCPU(object):
 
         slvr = self.solver
 
-	vis = ne.evaluate('sum(ebk,3)', {'ebk': self.compute_ebk_jones()}).squeeze(axis=(3,)).astype(slvr.ct)
+        vis = ne.evaluate('sum(ebk,3)',
+            {'ebk': self.compute_ebk_jones()}) \
+            .astype(slvr.ct)
+
+        # Due to this bug
+        # https://github.com/pydata/numexpr/issues/79
+        # numexpr may not reduce a source axis of size 1
+        # Work around this
+        vis = vis.squeeze(3) if slvr.nsrc <= 1 else vis
+
         assert vis.shape == (4, slvr.ntime, slvr.nbl, slvr.nchan)
 
         return vis

--- a/montblanc/impl/biro/v2/cpu/SolverCPU.py
+++ b/montblanc/impl/biro/v2/cpu/SolverCPU.py
@@ -373,10 +373,7 @@ class SolverCPU(object):
 
         slvr = self.solver
 
-	if (slvr.nsrc == 1):
-		vis = self.compute_ebk_jones().reshape(4, slvr.ntime, slvr.nbl, slvr.nchan)
-        else:
-		vis = ne.evaluate('sum(ebk,3)', {'ebk': self.compute_ebk_jones()})\
+	vis = ne.evaluate('sum(ebk,3)', {'ebk': self.compute_ebk_jones()}).squeeze()\
             .astype(slvr.ct)
         assert vis.shape == (4, slvr.ntime, slvr.nbl, slvr.nchan)
 

--- a/montblanc/impl/biro/v2/cpu/SolverCPU.py
+++ b/montblanc/impl/biro/v2/cpu/SolverCPU.py
@@ -373,7 +373,10 @@ class SolverCPU(object):
 
         slvr = self.solver
 
-        vis = ne.evaluate('sum(ebk,3)', {'ebk': self.compute_ebk_jones()})\
+	if (slvr.nsrc == 1):
+		vis = self.compute_ebk_jones().reshape(4, slvr.ntime, slvr.nbl, slvr.nchan)
+        else:
+		vis = ne.evaluate('sum(ebk,3)', {'ebk': self.compute_ebk_jones()})\
             .astype(slvr.ct)
         assert vis.shape == (4, slvr.ntime, slvr.nbl, slvr.nchan)
 

--- a/montblanc/impl/biro/v2/loaders/loaders.py
+++ b/montblanc/impl/biro/v2/loaders/loaders.py
@@ -41,18 +41,18 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
 	# Define transpose axes to convert file uvw order 
 	# to montblanc array shape: (ntime, nbl)
         if data_order == ORDER_BL_TIME:
-                file_uvw_shape = (nbl, ntime, 3)
-                uvw_transpose = (2,1,0)
+		file_uvw_shape = (nbl, ntime, 3)
+		uvw_transpose = (2,1,0)
 		file_ant_shape = (nbl, ntime)
 		ant_transpose = (1,0)
 		file_data_shape = (nbl, ntime, nchan,4)
-                data_transpose = (3,1,0,2)
+		data_transpose = (3,1,0,2)
         elif data_order == ORDER_TIME_BL:
-                file_uvw_shape = (ntime, nbl,  3)
-                uvw_transpose = (2,0,1)
+		file_uvw_shape = (ntime, nbl,  3)
+		uvw_transpose = (2,0,1)
 		file_ant_shape = (ntime, nbl)
 		file_data_shape = (ntime, nbl, nchan,4)
-                data_transpose = (3,0,1,2)
+		data_transpose = (3,0,1,2)
 	else:
 		raise ValueError('Invalid UVW ordering %s', uvw_order)
         
@@ -85,8 +85,8 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         ant1 = tm.getcol('ANTENNA1').reshape(file_ant_shape)
         ant2 = tm.getcol('ANTENNA2').reshape(file_ant_shape)
 	if (data_order == ORDER_BL_TIME):
-		ant1.transpose(ant_transpose)
-		ant2.transpose(ant_transpose)
+		ant1 = ant1.transpose(ant_transpose)
+		ant2 = ant2.transpose(ant_transpose)
 
         expected_ant_shape = (ntime,nbl)
 

--- a/montblanc/impl/biro/v2/loaders/loaders.py
+++ b/montblanc/impl/biro/v2/loaders/loaders.py
@@ -43,13 +43,17 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
                 raise ValueError('Invalid UVW ordering %s', uvw_order)
 
         # Define transpose axes to convert file uvw order 
-	# to montblanc array shape: (3, ntime, nbl)
+	# to montblanc array shape: (ntime, nbl)
         if uvw_order == ORDER_CASA:
                 file_uvw_shape = (nbl, ntime, 3)
                 uvw_transpose = (2,1,0)
+		file_weight_shape = (nbl, ntime, nchan,4)
+                weight_transpose = (3,1,0,2)
         else:
                 file_uvw_shape = (ntime, nbl,  3)
                 uvw_transpose = (2,0,1)
+		file_weight_shape = (ntime, nbl, nchan,4)
+                weight_transpose = (3,0,1,2)
 
         # Check that we're getting the correct shape...
         uvw_shape = (ntime*nbl, 3)
@@ -157,8 +161,8 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
 
             assert weight_vector.shape == (ntime*nbl, nchan, 4)
 
-            weight_vector = weight_vector.reshape(ntime,nbl,nchan,4) \
-                .transpose(3,0,1,2).astype(solver.ft)
+            weight_vector = weight_vector.reshape(file_weight_shape) \
+                .transpose(weight_transpose).astype(solver.ft)
 
             solver.transfer_weight_vector(np.ascontiguousarray(weight_vector))
 

--- a/montblanc/impl/biro/v2/loaders/loaders.py
+++ b/montblanc/impl/biro/v2/loaders/loaders.py
@@ -36,27 +36,27 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         tf = self.tables['freq']
 
         na, nbl, ntime, nchan = solver.na, solver.nbl, solver.ntime, solver.nchan
-	data_order = kwargs.get('data_order', ORDER_TIME_BL)
-        
-	# Define transpose axes to convert file uvw order 
-	# to montblanc array shape: (ntime, nbl)
+        data_order = kwargs.get('data_order', ORDER_TIME_BL)
+
+        # Define transpose axes to convert file uvw order
+        # to montblanc array shape: (ntime, nbl)
         if data_order == ORDER_BL_TIME:
-		file_uvw_shape = (nbl, ntime, 3)
-		uvw_transpose = (2,1,0)
-		file_ant_shape = (nbl, ntime)
-		ant_transpose = (1,0)
-		file_data_shape = (nbl, ntime, nchan,4)
-		data_transpose = (3,1,0,2)
+            file_uvw_shape = (nbl, ntime, 3)
+            uvw_transpose = (2,1,0)
+            file_ant_shape = (nbl, ntime)
+            ant_transpose = (1,0)
+            file_data_shape = (nbl, ntime, nchan,4)
+            data_transpose = (3,1,0,2)
         elif data_order == ORDER_TIME_BL:
-		file_uvw_shape = (ntime, nbl,  3)
-		uvw_transpose = (2,0,1)
-		file_ant_shape = (ntime, nbl)
-		file_data_shape = (ntime, nbl, nchan,4)
-		data_transpose = (3,0,1,2)
-	else:
-		raise ValueError('Invalid UVW ordering %s', uvw_order)
-        
-	# Check that we're getting the correct shape...
+            file_uvw_shape = (ntime, nbl,  3)
+            uvw_transpose = (2,0,1)
+            file_ant_shape = (ntime, nbl)
+            file_data_shape = (ntime, nbl, nchan,4)
+            data_transpose = (3,0,1,2)
+        else:
+            raise ValueError('Invalid UVW ordering %s', uvw_order)
+
+        # Check that we're getting the correct shape...
         uvw_shape = (ntime*nbl, 3)
 
         # Read in UVW
@@ -84,9 +84,9 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         # Get the baseline antenna pairs and correct the axes
         ant1 = tm.getcol('ANTENNA1').reshape(file_ant_shape)
         ant2 = tm.getcol('ANTENNA2').reshape(file_ant_shape)
-	if (data_order == ORDER_BL_TIME):
-		ant1 = ant1.transpose(ant_transpose)
-		ant2 = ant2.transpose(ant_transpose)
+        if data_order == ORDER_BL_TIME:
+            ant1 = ant1.transpose(ant_transpose)
+            ant2 = ant2.transpose(ant_transpose)
 
         expected_ant_shape = (ntime,nbl)
 
@@ -129,8 +129,8 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
             flag = np.logical_or(flag, flag_row[:,np.newaxis,np.newaxis])
 
             if init_weights == 'weight':
-                # Obtain weighting information from WEIGHT_SPECTRUM
-                # preferably, otherwise WEIGHtm.
+            # Obtain weighting information from WEIGHT_SPECTRUM
+            # preferably, otherwise WEIGHtm.
                 if tm.colnames().count('WEIGHT_SPECTRUM') > 0:
                     # Try obtain the weightings from WEIGHT_SPECTRUM firstm.
                     # It has the same dimensions as 'FLAG'


### PR DESCRIPTION
MeasurementSet data can be ordered **time x baseline** or **baseline x time**.

While Montblanc expects **time x baseline** orderings by default, this pull request allows loading from baseline x time orderings.
