### PR TITLE
Provide options for configuring E beam cube dimensions

### DIFF
--- a/montblanc/impl/biro/slvr_config.py
+++ b/montblanc/impl/biro/slvr_config.py
@@ -45,16 +45,6 @@ class BiroSolverConfigurationOptions(Options):
         'Governs the level of discretisation of '
         'the nu (frequency) dimension.')
 
-    E_BEAM_CONFIG = 'E_beam_config'
-    E_BEAM_CONFIG_DESCRIPTION = (
-        'A dictionary used to configure the E Beam. ',
-        'e.g. %s : { \'%s\': %s, \'%s\': %s, \'%s\': %s }' % (
-            E_BEAM_CONFIG,
-            E_BEAM_WIDTH, DEFAULT_E_BEAM_WIDTH,
-            E_BEAM_HEIGHT, DEFAULT_E_BEAM_HEIGHT,
-            E_BEAM_DEPTH, DEFAULT_E_BEAM_DEPTH))
-
-
     # Should a weight vector (sigma) be used to
     # when calculating the chi-squared values?
     WEIGHT_VECTOR = 'weight_vector'

--- a/montblanc/impl/biro/slvr_config.py
+++ b/montblanc/impl/biro/slvr_config.py
@@ -24,7 +24,39 @@ from montblanc.slvr_config import (SolverConfiguration,
     SolverConfigurationOptions as Options)
 
 class BiroSolverConfigurationOptions(Options):
-    # 
+    E_BEAM_WIDTH = 'beam_lw'
+    DEFAULT_E_BEAM_WIDTH = 50
+    E_BEAM_WIDTH_DESCRIPTION = (
+        'Width of the E Beam cube. ',
+        'Governs the level of discretisation of '
+        'the l dimension.')
+
+    E_BEAM_HEIGHT = 'beam_mh'
+    DEFAULT_E_BEAM_HEIGHT = 50
+    E_BEAM_HEIGHT_DESCRIPTION = (
+        'Height of the E Beam cube. ',
+        'Governs the level of discretisation of '
+        'the m dimension.')
+
+    E_BEAM_DEPTH = 'beam_nud'
+    DEFAULT_E_BEAM_DEPTH = 50
+    E_BEAM_DEPTH_DESCRIPTION = (
+        'Depth of the E Beam cube. ',
+        'Governs the level of discretisation of '
+        'the nu (frequency) dimension.')
+
+    E_BEAM_CONFIG = 'E_beam_config'
+    E_BEAM_CONFIG_DESCRIPTION = (
+        'A dictionary used to configure the E Beam. ',
+        'e.g. %s : { \'%s\': %s, \'%s\': %s, \'%s\': %s }' % (
+            E_BEAM_CONFIG,
+            E_BEAM_WIDTH, DEFAULT_E_BEAM_WIDTH,
+            E_BEAM_HEIGHT, DEFAULT_E_BEAM_HEIGHT,
+            E_BEAM_DEPTH, DEFAULT_E_BEAM_DEPTH))
+
+
+    # Should a weight vector (sigma) be used to
+    # when calculating the chi-squared values?
     WEIGHT_VECTOR = 'weight_vector'
     DEFAULT_WEIGHT_VECTOR = False
     VALID_WEIGHT_VECTOR = [True, False]
@@ -133,3 +165,8 @@ class BiroSolverConfiguration(SolverConfiguration):
 
         # Version
         self.setdefault(Options.VERSION, Options.DEFAULT_VERSION)
+
+        # Beam Dimensions
+        self.setdefault(Options.E_BEAM_WIDTH, Options.DEFAULT_E_BEAM_WIDTH)
+        self.setdefault(Options.E_BEAM_HEIGHT, Options.DEFAULT_E_BEAM_HEIGHT)
+        self.setdefault(Options.E_BEAM_DEPTH, Options.DEFAULT_E_BEAM_DEPTH)

--- a/montblanc/impl/biro/v4/BiroSolver.py
+++ b/montblanc/impl/biro/v4/BiroSolver.py
@@ -78,9 +78,6 @@ P = [
     prop_dict('X2', 'ft', 0.0),
 
     # Width of the beam cube dimension. l, m and lambda
-    prop_dict('beam_lw', 'int', 50),
-    prop_dict('beam_mh', 'int', 50),
-    prop_dict('beam_nud', 'int', 50),
     # Lower l and m coordinates of the beam cube
     prop_dict('beam_ll', 'ft', -0.5),
     prop_dict('beam_lm', 'ft', -0.5),
@@ -219,8 +216,26 @@ class BiroSolver(BaseSolver):
 
         super(BiroSolver, self).__init__(slvr_cfg)
 
+        # Configure the dimensions of the beam cube
+        self.beam_lw = self.slvr_cfg[Options.E_BEAM_WIDTH]
+        self.beam_mh = self.slvr_cfg[Options.E_BEAM_HEIGHT]
+        self.beam_nud = self.slvr_cfg[Options.E_BEAM_DEPTH]
+
         self.register_properties(P)
         self.register_arrays(A)
+
+    def get_properties(self):
+        # Obtain base solver property dictionary
+        # and add the beam cube dimensions to it
+        D = super(BiroSolver, self).get_properties()
+
+        D.update({
+            'beam_lw' : self.beam_lw,
+            'beam_mh' : self.beam_mh,
+            'beam_nud' : self.beam_nud
+        })
+
+        return D
 
     def get_default_base_ant_pairs(self):
         """

--- a/montblanc/tests/test_biro_v4.py
+++ b/montblanc/tests/test_biro_v4.py
@@ -396,25 +396,43 @@ class TestBiroV4(unittest.TestCase):
 
     def test_E_beam_float(self):
         """ Test the E Beam float kernel """
+        # Randomly configure the beam cube dimensions
+        beam_lw = np.random.randint(50, 60)
+        beam_mh = np.random.randint(50, 60)
+        beam_nud = np.random.randint(50, 60)
 
         slvr_cfg = BiroSolverConfiguration(na=32, ntime=50, nchan=64,
             sources=montblanc.sources(point=10, gaussian=10),
+            beam_lw=beam_lw, beam_mh=beam_mh, beam_nud=beam_nud,
             dtype=Options.DTYPE_FLOAT,
             pipeline=Pipeline([RimeEBeam()]))
 
         with solver(slvr_cfg) as slvr:
+            # Check that the beam cube dimensions are
+            # correctly configured
+            self.assertTrue(slvr.E_beam_shape == 
+                (beam_lw, beam_mh, beam_nud, 4))
 
             self.E_beam_test_impl(slvr, cmp={'rtol': 1e-4})
 
     def test_E_beam_double(self):
         """ Test the E Beam double kernel """
+        # Randomly configure the beam cube dimensions
+        beam_lw = np.random.randint(50, 60)
+        beam_mh = np.random.randint(50, 60)
+        beam_nud = np.random.randint(50, 60)
 
         slvr_cfg = BiroSolverConfiguration(na=32, ntime=50, nchan=64,
             sources=montblanc.sources(point=10, gaussian=10),
+            beam_lw=beam_lw, beam_mh=beam_mh, beam_nud=beam_nud,
             dtype=Options.DTYPE_DOUBLE,
             pipeline=Pipeline([RimeEBeam()]))
 
         with solver(slvr_cfg) as slvr:
+            # Check that the beam cube dimensions are
+            # correctly configured
+            self.assertTrue(slvr.E_beam_shape ==
+                (beam_lw, beam_mh, beam_nud, 4))
 
             self.E_beam_test_impl(slvr)
 

--- a/montblanc/tests/test_utils.py
+++ b/montblanc/tests/test_utils.py
@@ -132,21 +132,39 @@ class TestUtils(unittest.TestCase):
         do_check(3500, 3500*3499//2, 3500*3501//2)   # SKA
 
     def test_random_like(self):
-        shape = (np.random.randint(1, 50), np.random.randint(1, 50))
-        dtype_list = [np.float32, np.float64, np.complex64, np.complex128]
-        dtype = dtype_list[np.random.randint(0,len(dtype_list))]
+        """
+        Test that the random_like function produces sensible data
+        """
 
-        ary = np.empty(shape=shape, dtype=dtype)
-        random_ary = mbu.random_like(ary)
+        # Try for floats and complex data
+        for dtype in [np.float32, np.float64, np.complex64, np.complex128]:
+            # Test random array creation with same
+            # shape and type as existing array
+            shape = (np.random.randint(1, 50), np.random.randint(1, 50))
+            ary = np.empty(shape=shape, dtype=dtype)    
+            random_ary = mbu.random_like(ary)
 
-        self.assertTrue(random_ary.shape == ary.shape)
-        self.assertTrue(random_ary.dtype == dtype)
+            # Test that that the shape and type is correct
+            self.assertTrue(random_ary.shape == ary.shape)
+            self.assertTrue(random_ary.dtype == dtype)
 
-        shape = (np.random.randint(1, 50), np.random.randint(1, 50))
-        random_ary = mbu.random_like(shape=shape, dtype=dtype)
+            # Test that we're getting complex data out
+            if np.issubdtype(dtype, np.complexfloating):
+                proportion_cplx = np.sum(np.iscomplex(random_ary)) / random_ary.size
+                self.assertTrue(proportion_cplx > 0.9)
 
-        self.assertTrue(random_ary.shape == shape)
-        self.assertTrue(random_ary.dtype == dtype)
+            # Test random array creation with supplied shape and type
+            shape = (np.random.randint(1, 50), np.random.randint(1, 50))
+            random_ary = mbu.random_like(shape=shape, dtype=dtype)
+
+            # Test that that the shape and type is correct
+            self.assertTrue(random_ary.shape == shape)
+            self.assertTrue(random_ary.dtype == dtype)
+
+            # Test that we're getting complex data out
+            if np.issubdtype(dtype, np.complexfloating):
+                proportion_cplx = np.sum(np.iscomplex(random_ary)) / random_ary.size
+                self.assertTrue(proportion_cplx > 0.9)
 
     def test_sky_model(self):
         """ Test sky model file loading """


### PR DESCRIPTION
The dimensions of the E Beam cube can now be set on the Solver Configuration object.
- **beam_lw**: The width of the cube's *l* dimension.
- **beam_mh**: The height of the cube's *m* dimension.
- **beam_nud**: The depth of the cube's *nu* or, *frequency* dimension.

These options define the level of discretisation on the cube.

```python
import montblanc

slvr_cfg = montblanc.rime_solver_cfg(...,
   beam_lw=60, beam_mh=60, beam_nud=70)

with montblanc.rime_solver(slvr_cfg) as slvr:
   ...
   slvr.solve()
```

