### PR TITLE
Improve cub installation and update README.md

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "montblanc/src/cub"]
-	path = montblanc/src/cub
-	url = https://github.com/NVlabs/cub

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Montblanc is licensed under the GNU GPL v2.0 License.
 
 ## Requirements
 
-- PyCUDA 2015.1
+- PyCUDA 2015.1.3
 - A Kepler NVIDIA GPU for more recent functionality.
 
 ## Installation
@@ -17,26 +17,41 @@ Certain pre-requisites must be installed, prior to calling the `setup.py` script
 
 ### Pre-requisites
 
-Montblanc depends on [NVIDIA cub 1.4.1][cub]. It can be cloned as a submodule
-prior to running `python setup.py`:
-
-    # git submodule init
-    # git submodule update --depth 1
-
-An experimental alternative is to download [NVIDIA cub 1.4.1][cub] and unzip it
-in the include directory of `nvcc`.
-
-You'll also need to install the [python-casacore][pyrap] library which, in turn, is dependent on [casacore2][casacore]. It may be easier to add the [radio astronomy PPA][radio-astro-ppa]  and get the binaries from there.
+- **[libffi][libffi]** development files, required by cffi. On ubuntu 14.04, you can run:
+    ```bash
+    $ sudo apt-get install libffi-dev
+    ```
+- **[python-casacore][pyrap]** which depends on **[casacore2][casacore]**. On Ubuntu 14.04 add the [radio astronomy PPA][radio-astro-ppa]  and get the binaries from there:
+    ```bash
+    $ sudo apt-get install software-properties-common
+    $ sudo add-apt-repository ppa:radio-astro/main
+    $ sudo apt-get update
+    $ sudo apt-get install python-casacore
+    ```
+- **[PyCUDA 2015.1.3][pycuda]**. setup.py will attempt to install this automatically,
+    but this might not work if you have a non-standard CUDA install location. It's worth running
+    ```bash
+    $ python -c 'import pycuda.autoinit'
+    ```
+    to check if your pycuda can talk to the NVIDIA driver. If not, manually download
+    and install [PyCUDA][pycuda].
+- **[cub 1.5.1][cub]**. setup.py will attempt to download this from github
+    and install to the correct directory during install. If this fails do the following:
+    ```bash
+    $ wget -c https://codeload.github.com/NVlabs/cub/zip/1.5.1
+    $ mv 1.5.1 cub.zip
+    $ python setup.py install
+    ```
 
 ### Building the package
 
 Run
 
-    # python setup.py build
+    $ python setup.py build
 
 to build the package. The following:
 
-    # python setup.py install
+    $ python setup.py install
 
 should install the package.
 
@@ -44,22 +59,22 @@ should install the package.
 
 Once the libraries have been compiled you should be able to run the
 
-    # cd tests
-    # python -c 'import montblanc; montblanc.test()'
-    # python -m unittest test_biro_v4.TestBiroV4.test_sum_coherencies_double
+    $ cd tests
+    $ python -c 'import montblanc; montblanc.test()'
+    $ python -m unittest test_biro_v4.TestBiroV4.test_sum_coherencies_double
 
 which will run the entire test suite or only the specified test case, respectively. The reported times are for the entire test case with numpy code, and not just the CUDA kernels.
 
 If you're running on an ubuntu laptop with optimus technology, you may have to install bumblebee and run
 
-    # optirun python -c 'import montblanc; montblanc.test()'
+    $ optirun python -c 'import montblanc; montblanc.test()'
 
 ## Playing with a Measurement Set
 
 You could also try run
 
-    # cd examples
-    # python MS_example.py /home/user/data/WSRT.MS -np 10 -ng 10 -c 100
+    $ cd examples
+    $ python MS_example.py /home/user/data/WSRT.MS -np 10 -ng 10 -c 100
 
 which sets up things based on the supplied Measurement Set, with 10 point and 10 gaussian sources. It performs 100 iterations of the pipeline.
 
@@ -89,6 +104,7 @@ Everything should be considered unstable and subject to change. I will make an e
 [pyrap]:https://github.com/casacore/python-casacore
 [casacore]:https://github.com/casacore/casacore
 [radio-astro-ppa]:https://launchpad.net/~radio-astro/+archive/main
+[libffi]:https://sourceware.org/libffi/
 [biro-paper-arxiv]:http://arxiv.org/abs/1501.05304
 [biro-paper-mnras]:http://mnras.oxfordjournals.org/content/450/2/1308.abstract
 [montblanc-paper-arxiv]:http://arxiv.org/abs/1501.07719

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,129 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import hashlib
 import os
+import urllib2
+import shutil
 import subprocess
+import sys
+import zipfile
 from setuptools import setup, find_packages
+
+def dl_cub(cub_url, cub_archive_name):
+    """ Download cub archive from cub_url and store it in cub_archive_name """
+    with open(cub_archive_name, 'wb') as f:
+        remote_file = urllib2.urlopen(cub_url)
+        meta = remote_file.info()
+        remote_file_size = int(meta.getheaders("Content-Length")[0])
+
+        local_file_size = 0
+        block_size = 128*1024
+
+        while True:
+            data = remote_file.read(block_size)
+
+            if not data:
+                break
+
+            local_file_size += len(data)
+            f.write(data)
+            status = r"Downloading %s %10d  [%3.2f%%]" % (cub_url,
+                local_file_size, local_file_size * 100. / remote_file_size)
+            status = status + chr(8)*(len(status)+1)
+            print status,
+
+        remote_file.close()
+
+def sha_hash_file(filename):
+    # Compute the SHA1 hash
+    hash_sha = hashlib.sha1()
+
+    with open(filename, 'rb') as f:
+        for chunk in iter(lambda: f.read(1024*1024), b""):
+            hash_sha.update(chunk)
+
+    return hash_sha.hexdigest()
+
+def is_cub_installed(readme_filename, header_filename, cub_version_str):
+    # Check if the cub.h exists
+    if not os.path.exists(header_filename) or not os.path.isfile(header_filename):
+        return False
+
+    # Check if the README.md exists
+    if not os.path.exists(readme_filename) or not os.path.isfile(readme_filename):
+        return False
+
+    # Search for the version string, returning True if found
+    with open(readme_filename, 'r') as f:
+        for line in f:
+            if line.find(cub_version_str) != -1:
+                return True
+
+    # Nothing found!
+    return False
+
+def install_cub():
+    """ Download
+    s and installs cub """
+    cub_zip_file = 'cub.zip'
+    cub_url = 'https://codeload.github.com/NVlabs/cub/zip/1.5.1'
+    cub_sha_hash = 'b04f434f42267ff892d92b9e9e303b8e16f1dd32'
+    cub_zip_dir = 'cub-1.5.1'
+    src_path = os.path.join('montblanc', 'src')
+    cub_unzipped_path = os.path.join(src_path, cub_zip_dir)
+    cub_new_unzipped_path = os.path.join(src_path, 'cub')
+    cub_header = os.path.join(cub_new_unzipped_path, 'cub', 'cub.cuh')
+    cub_readme = os.path.join(cub_new_unzipped_path, 'README.md' )
+    cub_version_str = 'Current release: v1.5.1 (12/28/2015)'
+
+    # Check for a reasonably valid install
+    cub_installed = is_cub_installed(cub_readme, cub_header, cub_version_str)
+    print 'NVIDIA cub installed: %s' % cub_installed
+    if cub_installed:
+        return
+
+    # Do we already have a valid cub zip file
+    have_valid_cub_file = (os.path.exists(cub_zip_file) and
+        os.path.isfile(cub_zip_file) and
+        sha_hash_file(cub_zip_file) == cub_sha_hash)
+
+    print 'NVIDIA cub archive downloaded: %s' % have_valid_cub_file
+
+    # Download if we don't have a valid file
+    if not have_valid_cub_file:
+        dl_cub(cub_url, cub_zip_file)
+        cub_file_sha_hash = sha_hash_file(cub_zip_file)
+
+        # Compare against our supplied hash
+        assert cub_sha_hash == cub_file_sha_hash, \
+             ('Hash of file %s downloaded from %s '
+            'is %s and does not match the expected '
+            'hash of %s. Please manually download '
+            'as per the README.md instructions.') % (cub_zip_file,
+                cub_url, cub_sha_hash, cub_file_sha_hash)
+
+    # Unzip into montblanc/src/cub
+    with zipfile.ZipFile(cub_zip_file, 'r') as zip_file:
+        # Remove any existing installs
+        shutil.rmtree(cub_unzipped_path, ignore_errors=True)
+        shutil.rmtree(cub_new_unzipped_path, ignore_errors=True)
+
+        # Unzip
+        src_path = os.path.join('montblanc', 'src')
+        zip_file.extractall(src_path)
+
+        # Rename
+        shutil.move(cub_unzipped_path, cub_new_unzipped_path)
+
+        print 'NVIDIA cub archive unzipped into %s' % cub_new_unzipped_path
+
+    assert is_cub_installed(cub_readme, cub_header, cub_version_str),  \
+        ('cub installed unexpectedly failed!')
+
+    print 'NVIDIA cub install successful'
+
+install_cub()
 
 def get_version():
     # Versioning code here, based on


### PR DESCRIPTION
Removed cub submodule, which resulted in a large git clone.
Instead, introduced an install hook in setup.py which downloads
cub and installs it to the correct location.

Also improved the README.md pre-requisite section.