### PR TITLE
Fix flags

### DIFF
--- a/montblanc/impl/biro/v2/BiroSolver.py
+++ b/montblanc/impl/biro/v2/BiroSolver.py
@@ -149,9 +149,15 @@ A = [
         default=1,
         test=lambda slvr, ary: (rary(ary)-0.5)*1e-2),
 
+    ary_dict('flag', (4, 'ntime', 'nbl', 'nchan'), np.int32,
+        default=0,
+        test=lambda slvr, ary: np.random.random_integers(
+            0, 1, size=ary.shape)),
+
     ary_dict('weight_vector', (4,'ntime','nbl','nchan'), 'ft',
         default=1,
         test=lambda slvr, ary: rary(ary)),
+
     ary_dict('bayes_data', (4,'ntime','nbl','nchan'), 'ct',
         default=0,
         test=lambda slvr, ary: rary(ary)),

--- a/montblanc/impl/biro/v2/BiroSolver.py
+++ b/montblanc/impl/biro/v2/BiroSolver.py
@@ -149,7 +149,7 @@ A = [
         default=1,
         test=lambda slvr, ary: (rary(ary)-0.5)*1e-2),
 
-    ary_dict('flag', (4, 'ntime', 'nbl', 'nchan'), np.uint8,
+    ary_dict('flag', (4, 'ntime', 'nbl', 'nchan'), np.int32,
         default=0,
         test=lambda slvr, ary: np.random.random_integers(
             0, 1, size=ary.shape)),

--- a/montblanc/impl/biro/v2/BiroSolver.py
+++ b/montblanc/impl/biro/v2/BiroSolver.py
@@ -149,7 +149,7 @@ A = [
         default=1,
         test=lambda slvr, ary: (rary(ary)-0.5)*1e-2),
 
-    ary_dict('flag', (4, 'ntime', 'nbl', 'nchan'), np.int32,
+    ary_dict('flag', (4, 'ntime', 'nbl', 'nchan'), np.uint8,
         default=0,
         test=lambda slvr, ary: np.random.random_integers(
             0, 1, size=ary.shape)),

--- a/montblanc/impl/biro/v2/gpu/RimeGaussBSum.py
+++ b/montblanc/impl/biro/v2/gpu/RimeGaussBSum.py
@@ -44,6 +44,7 @@ DOUBLE_PARAMS = {
 
 KERNEL_TEMPLATE = string.Template("""
 #include <cstdio>
+#include <stdint.h>
 #include \"math_constants.h\"
 #include <montblanc/include/abstraction.cuh>
 
@@ -77,7 +78,7 @@ void rime_gauss_B_sum_impl(
     typename Tr::ft * wavelength,
     int * ant_pairs,
     typename Tr::ct * jones_EK_scalar,
-    int * flag,
+    uint8_t * flag,
     typename Tr::ft * weight_vector,
     typename Tr::ct * visibilities,
     typename Tr::ct * data_vis,
@@ -406,7 +407,7 @@ rime_gauss_B_sum_ ## symbol ## chi_ ## ft( \
     ft * wavelength, \
     int * ant_pairs, \
     ct * jones_EK_scalar, \
-    int * flag, \
+    uint8_t * flag, \
     ft * weight_vector, \
     ct * visibilities, \
     ct * data_vis, \

--- a/montblanc/impl/biro/v2/gpu/RimeGaussBSum.py
+++ b/montblanc/impl/biro/v2/gpu/RimeGaussBSum.py
@@ -44,7 +44,6 @@ DOUBLE_PARAMS = {
 
 KERNEL_TEMPLATE = string.Template("""
 #include <cstdio>
-#include <stdint.h>
 #include \"math_constants.h\"
 #include <montblanc/include/abstraction.cuh>
 
@@ -78,7 +77,7 @@ void rime_gauss_B_sum_impl(
     typename Tr::ft * wavelength,
     int * ant_pairs,
     typename Tr::ct * jones_EK_scalar,
-    uint8_t * flag,
+    int * flag,
     typename Tr::ft * weight_vector,
     typename Tr::ct * visibilities,
     typename Tr::ct * data_vis,
@@ -407,7 +406,7 @@ rime_gauss_B_sum_ ## symbol ## chi_ ## ft( \
     ft * wavelength, \
     int * ant_pairs, \
     ct * jones_EK_scalar, \
-    uint8_t * flag, \
+    int * flag, \
     ft * weight_vector, \
     ct * visibilities, \
     ct * data_vis, \

--- a/montblanc/impl/biro/v2/loaders/loaders.py
+++ b/montblanc/impl/biro/v2/loaders/loaders.py
@@ -25,6 +25,20 @@ import montblanc.impl.common.loaders
 
 from montblanc.config import (BiroSolverConfig as Options)
 
+# Measurement Set string constants
+UVW = 'UVW'
+CHAN_FREQ = 'CHAN_FREQ'
+REF_FREQUENCY = 'REF_FREQUENCY'
+ANTENNA1 = 'ANTENNA1'
+ANTENNA2 = 'ANTENNA2'
+DATA = 'DATA'
+FLAG = 'FLAG'
+FLAG_ROW = 'FLAG_ROW'
+WEIGHT_SPECTRUM = 'WEIGHT_SPECTRUM'
+WEIGHT = 'WEIGHT'
+SIGMA_SPECTRUM = 'SIGMA_SPECTRUM'
+SIGMA = 'SIGMA'
+
 class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
     def load(self, solver, slvr_cfg):
         """
@@ -60,7 +74,7 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
 
         # Read in UVW
         # Reshape the array and correct the axes
-        ms_uvw = tm.getcol('UVW')
+        ms_uvw = tm.getcol(UVW)
         assert ms_uvw.shape == uvw_shape, \
             'MS UVW shape %s != expected %s' % (ms_uvw.shape,uvw_shape)
 
@@ -71,17 +85,17 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         solver.transfer_uvw(np.ascontiguousarray(uvw))
 
         # Determine the wavelengths
-        freqs = tf.getcol('CHAN_FREQ')
+        freqs = tf.getcol(CHAN_FREQ)
         wavelength = (montblanc.constants.C/freqs[0]).astype(solver.ft)
         solver.transfer_wavelength(wavelength)
 
         # First dimension also seems to be of size 1 here...
         # Divide speed of light by frequency to get the wavelength here.
-        solver.set_ref_wave(montblanc.constants.C/tf.getcol('REF_FREQUENCY')[0])
+        solver.set_ref_wave(montblanc.constants.C/tf.getcol(REF_FREQUENCY)[0])
 
         # Get the baseline antenna pairs and correct the axes
-        ant1 = tm.getcol('ANTENNA1').reshape(file_ant_shape)
-        ant2 = tm.getcol('ANTENNA2').reshape(file_ant_shape)
+        ant1 = tm.getcol(ANTENNA1).reshape(file_ant_shape)
+        ant2 = tm.getcol(ANTENNA2).reshape(file_ant_shape)
         if data_order == Options.DATA_ORDER_OTHER:
             ant1 = ant1.transpose(ant_transpose)
             ant2 = ant2.transpose(ant_transpose)
@@ -89,10 +103,12 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         expected_ant_shape = (ntime,nbl)
 
         assert expected_ant_shape == ant1.shape, \
-            'ANTENNA1 shape is %s != expected %s' % (ant1.shape,expected_ant_shape)
+            '{a1} shape is {r} != expected {e}'.format(
+                a=ANTENNA1, r=ant1.shape, e=expected_ant_shape)
 
         assert expected_ant_shape == ant2.shape, \
-            'ANTENNA2 shape is %s != expected %s' % (ant2.shape,expected_ant_shape)
+            '{a} shape is {r} != expected {e}'.format(
+                a=ANTENNA2, r=ant2.shape, e=expected_ant_shape)
 
         ant_pairs = np.vstack((ant1,ant2)).reshape(solver.ant_pairs_shape)
 
@@ -100,61 +116,106 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         solver.transfer_ant_pairs(np.ascontiguousarray(ant_pairs))
 
         # Load in visibility data, if it exists.
-        if tm.colnames().count('DATA') > 0:
+        if tm.colnames().count(DATA) > 0:
+            montblanc.log.info('{lp} Loading visibilities '
+                'into the {bd} array'.format(
+                    lp=self.LOG_PREFIX, bd='bayes_data'))
             # Obtain visibilities stored in the DATA column
             # This comes in as (ntime*nbl,nchan,4)
             vis_data = tm.getcol('DATA').reshape(file_data_shape) \
                 .transpose(data_transpose).astype(solver.ct)
             solver.transfer_bayes_data(np.ascontiguousarray(vis_data))
+        else:
+            montblanc.log.info('{lp} No visibilities found.'
+                .format(lp=self.LOG_PREFIX))
+            # Should be zeroed out by array defaults
+
+        # Load in flag data if available
+        if tm.colnames().count(FLAG) > 0:
+            montblanc.log.info('{lp} Loading flag data.'.format(
+                    lp=self.LOG_PREFIX))
+
+            flag = tm.getcol(FLAG)
+            flag_row = tm.getcol(FLAG_ROW)
+
+            # Incorporate the flag_row data into the larger flag matrix
+            flag = np.logical_or(flag, flag_row[:,np.newaxis,np.newaxis])
+
+            # Reshape and transpose
+            flag = flag.reshape(file_data_shape).transpose(
+                data_transpose).astype(solver.flag_dtype)
+
+            # Transfer, asking for contiguity
+            solver.transfer_flag(np.ascontiguousarray(flag))
+        else:
+            montblanc.log.info('{lp} No flag data found.'
+                .format(lp=self.LOG_PREFIX))
+            # Should be zeroed out by array defaults
 
         # Should we initialise our weights from the MS data?
         init_weights = slvr_cfg.get(Options.INIT_WEIGHTS)
  
-        # Load in flag and weighting data, if it exists
-        if init_weights is not Options.INIT_WEIGHTS_NONE and \
-            tm.colnames().count('FLAG') > 0:
-            # Get the flag data. Data flagged as True should be ignored,
-            # therefore we flip the values so that when we multiply flag
-            # by the weights later, a False value zeroes out the weight
-            flag = (tm.getcol('FLAG') == False)
-            flag_row = (tm.getcol('FLAG_ROW') == False)
-
-            # Incorporate the flag_row data into the larger
-            # flag matrix
-            flag = np.logical_or(flag, flag_row[:,np.newaxis,np.newaxis])
-
+        # Load in weighting data, if it exists
+        if init_weights is not Options.INIT_WEIGHTS_NONE:
             if init_weights == Options.INIT_WEIGHTS_WEIGHT:
             # Obtain weighting information from WEIGHT_SPECTRUM
             # preferably, otherwise WEIGHT.
-                if tm.colnames().count('WEIGHT_SPECTRUM') > 0:
+                if tm.colnames().count(WEIGHT_SPECTRUM) > 0:
                     # Try obtain the weightings from WEIGHT_SPECTRUM first.
-                    # It has the same dimensions as 'FLAG'
-                    weight_vector = flag*tm.getcol('WEIGHT_SPECTRUM')
-                elif tm.colnames().count('WEIGHT') > 0:
-                    # Otherwise we should try obtain the weightings from WEIGHt.
+                    montblanc.log.info('{lp} Initialising {wv} from {n}.'
+                        .format(lp=self.LOG_PREFIX, wv='weight_vector',
+                            n=WEIGHT_SPECTRUM))
+
+                    weight_vector = tm.getcol(WEIGHT_SPECTRUM)
+                elif tm.colnames().count(WEIGHT) > 0:
+                    # Otherwise we should try obtain the weightings from WEIGHT.
                     # This doesn't have per-channel weighting, so we introduce
                     # this with a broadcast
-                    weight_vector = flag * \
-                        (tm.getcol('WEIGHT')[:,np.newaxis,:]*np.ones(shape=(nchan,1)))
+                    montblanc.log.info('{lp} Initialising {wv} from {n}.'
+                        .format(lp=self.LOG_PREFIX, wv='weight_vector',
+                            n=WEIGHT))
+
+                    weight = tm.getcol(WEIGHT)[:,np.newaxis,:]
+                    weight_vector = weight*np.ones(shape=(nchan,1))
                 else:
-                    # Just use the boolean flags as weighting values
-                    weight_vector = flag.astype(solver.ft)
+                    # We couldn't find anything, set to one
+                    montblanc.log.info('{lp} No {ws} or {w} columns. '
+                        'Initialising {wv} from with ones.'
+                        .format(lp=self.LOG_PREFIX, ws=WEIGHT_SPECTRUM,
+                            w=WEIGHT, wv='weight_vector'))
+
+                    weight_vector = np.ones(
+                        shape=solver.weight_vector_shape,
+                        dtype=solver.weight_vector_dtype)
             elif init_weights == Options.INIT_WEIGHTS_SIGMA:
                 # Obtain weighting information from SIGMA_SPECTRUM
                 # preferably, otherwise SIGMA.
-                if tm.colnames().count('SIGMA_SPECTRUM') > 0:
-                    # Try obtain the weightings from WEIGHT_SPECTRUM firstm.
-                    # It has the same dimensions as 'FLAG'
-                    weight_vector = flag*tm.getcol('SIGMA_SPECTRUM')
-                elif tm.colnames().count('SIGMA') > 0:
-                    # Otherwise we should try obtain the weightings from WEIGHtm.
+                if tm.colnames().count(SIGMA_SPECTRUM) > 0:
+                    # Try obtain the weightings from WEIGHT_SPECTRUM first.
+                    montblanc.log.info('{lp} Initialising {wv} from {n}.'
+                        .format(lp=self.LOG_PREFIX, wv='weight_vector',
+                            n=SIGMA_SPECTRUM))
+
+                    weight_vector = tm.getcol(SIGMA_SPECTRUM)
+                elif tm.colnames().count(SIGMA) > 0:
+                    # Otherwise we should try obtain the weightings from WEIGHT.
                     # This doesn't have per-channel weighting, so we introduce
                     # this with a broadcast
-                    weight_vector = flag * \
-                        (tm.getcol('SIGMA')[:,np.newaxis,:]*np.ones(shape=(nchan,1)))
+                    montblanc.log.info('{lp} Initialising {wv} from {n}.'
+                        .format(lp=self.LOG_PREFIX, wv='weight_vector',
+                            n=SIGMA))
+
+                    sigma = tm.getcol(SIGMA)[:,np.newaxis,:]
+                    weight_vector = (sigma*np.ones(shape=(nchan,1)))
                 else:
-                    # Just use the boolean flags as weighting values
-                    weight_vector = flag.astype(solver.ft)
+                    # We couldn't find anything, set to one
+                    montblanc.log.info('{lp} No {ss} or {s} columns. '
+                        'Initialising {wv} from with ones.'
+                        .format(lp=self.LOG_PREFIX, ss=SIGMA_SPECTRUM,
+                            s=SIGMA, wv='weight_vector'))
+
+                    weight_vector = np.ones(shape=solver.weight_vector_shape,
+                        dtype=solver.weight_vector_dtype)
             else:
                 raise Exception, 'init_weights used incorrectly!'
 

--- a/montblanc/impl/biro/v4/BiroSolver.py
+++ b/montblanc/impl/biro/v4/BiroSolver.py
@@ -190,7 +190,7 @@ A = [
         test=lambda slvr, ary: rary(ary)),
 
     # Visibility flagging arrays
-    ary_dict('flag', ('ntime', 'nbl', 'nchan', 4), np.int32,
+    ary_dict('flag', ('ntime', 'nbl', 'nchan', 4), np.uint8,
         default=0,
         test=lambda slvr, ary: np.random.random_integers(
             0, 1, size=ary.shape)),

--- a/montblanc/impl/biro/v4/BiroSolver.py
+++ b/montblanc/impl/biro/v4/BiroSolver.py
@@ -189,6 +189,12 @@ A = [
         default=np.array([1,0,0,1])[np.newaxis,np.newaxis,np.newaxis,:],
         test=lambda slvr, ary: rary(ary)),
 
+    # Visibility flagging arrays
+    ary_dict('flag', ('ntime', 'nbl', 'nchan', 4), np.int32,
+        default=0,
+        test=lambda slvr, ary: np.random.random_integers(
+            0, 1, size=ary.shape)),
+
     # Bayesian Data
     ary_dict('weight_vector', ('ntime','nbl','nchan',4), 'ft',
         default=1,

--- a/montblanc/impl/biro/v4/gpu/RimeSumCoherencies.py
+++ b/montblanc/impl/biro/v4/gpu/RimeSumCoherencies.py
@@ -44,6 +44,7 @@ DOUBLE_PARAMS = {
 }
 
 KERNEL_TEMPLATE = string.Template("""
+#include <stdint.h>
 #include <cstdio>
 #include \"math_constants.h\"
 #include <montblanc/include/abstraction.cuh>
@@ -107,7 +108,7 @@ void rime_sum_coherencies_impl(
     typename Tr::ft * frequency,
     int * ant_pairs,
     typename Tr::ct * jones,
-    int * flag,
+    uint8_t * flag,
     typename Tr::ft * weight_vector,
     typename Tr::ct * bayes_data,
     typename Tr::ct * G_term,
@@ -356,7 +357,7 @@ rime_sum_coherencies_ ## symbol ## chi_ ## ft( \
     ft * frequency, \
     int * ant_pairs, \
     ct * jones, \
-    int * flag, \
+    uint8_t * flag, \
     ft * weight_vector, \
     ct * bayes_data, \
     ct * G_term, \

--- a/montblanc/impl/biro/v5/gpu/RimeSumCoherencies.py
+++ b/montblanc/impl/biro/v5/gpu/RimeSumCoherencies.py
@@ -61,7 +61,7 @@ class RimeSumCoherencies(montblanc.impl.biro.v4.gpu.RimeSumCoherencies.RimeSumCo
 
         self.kernel(slvr.uvw_gpu, gauss, sersic,
             slvr.frequency_gpu, slvr.ant_pairs_gpu,
-            slvr.jones_gpu, slvr.weight_vector_gpu,
+            slvr.jones_gpu, slvr.flag_gpu, slvr.weight_vector_gpu,
             slvr.bayes_data_gpu, slvr.G_term_gpu,
             slvr.vis_gpu, slvr.chi_sqrd_result_gpu,
             stream=stream, **self.launch_params)

--- a/montblanc/impl/common/loaders/loaders.py
+++ b/montblanc/impl/common/loaders/loaders.py
@@ -21,6 +21,7 @@
 import pyrap.tables as pt
 import os
 
+import montblanc
 import montblanc.util as mbu
 
 from montblanc.api.loaders import BaseLoader
@@ -29,6 +30,8 @@ ANTENNA_TABLE = 'ANTENNA'
 SPECTRAL_WINDOW = 'SPECTRAL_WINDOW'
 
 class MeasurementSetLoader(BaseLoader):
+    LOG_PREFIX = 'LOADER:'
+
     def __init__(self, msfile):
         super(MeasurementSetLoader, self).__init__()
 
@@ -36,6 +39,9 @@ class MeasurementSetLoader(BaseLoader):
         self.msfile = msfile
         self.antfile = os.path.join(self.msfile, ANTENNA_TABLE)
         self.freqfile = os.path.join(self.msfile, SPECTRAL_WINDOW)
+
+        montblanc.log.info("{lp} Opening Measurement Set {ms}.".format(
+            lp=self.LOG_PREFIX, ms=self.msfile))
 
         self.tables['main'] = pt.table(self.msfile, ack=False) \
             .query('ANTENNA1 != ANTENNA2')

--- a/montblanc/tests/test_biro_v4.py
+++ b/montblanc/tests/test_biro_v4.py
@@ -249,7 +249,7 @@ class TestBiroV4(unittest.TestCase):
             with solver(p_slvr_cfg) as slvr:
 
                 self.sum_coherencies_test_impl(slvr,
-                    cmp={'rtol': 1e-4},
+                    cmp={'rtol': 1e-3},
                     weight_vector=wv)
 
     def test_sum_coherencies_double(self):


### PR DESCRIPTION
Separate the flag and weight values. Previously they were combined into weight_vector which made MeasurementSet logic difficult to deal with. In particular, when a single sigma squared value was used to calculate the chi-squared instead of a weight vector, model and observed visibilities would not be zeroed and the resulting chi-squared would be incorrect.

Now, MS flags are separately maintained and loaded from the MS weight values. Flagging is applied  to both the model and observed visibilities prior to writing the model to global GPU memory and post reading the observed visibilities from global GPU memory. In effect, if a polarisation is flagged both the polarisation in the visibility *and* the chi-squared will be zeroed out.