### PR TITLE
Improve test cases

### DIFF
--- a/montblanc/examples/MS_test.py
+++ b/montblanc/examples/MS_test.py
@@ -21,40 +21,71 @@
 import numpy as np
 import montblanc
 
+from montblanc.config import (BiroSolverConfiguration,
+    BiroSolverConfigurationOptions as Options)
+
 if __name__ == '__main__':
     import sys
     import argparse
 
     parser = argparse.ArgumentParser(description='RIME MS test script')
     parser.add_argument('msfile', help='Measurement Set File')
-    parser.add_argument('-v','--version',dest='version', type=str, default='v2', choices=['v2','v3'],
+    parser.add_argument('-v','--version',dest='version', type=str, default='v2', choices=['v2','v3', 'v4'],
         help='BIRO Pipeline Version.')
 
     args = parser.parse_args(sys.argv[1:])
 
     # Get the solver.
-
     slvr_cfg = montblanc.rime_solver_cfg(msfile=args.msfile,
         sources=montblanc.sources(point=1, gaussian=0, sersic=0),
         dtype='double', version=args.version)
 
     with montblanc.rime_solver(slvr_cfg) as slvr:
-        # Create point sources at zeros
-        l=slvr.ft(np.ones(slvr.nsrc))*0.1
-        m=slvr.ft(np.ones(slvr.nsrc))*0.25
-        lm=np.array([l,m], dtype=slvr.ft).reshape(2,slvr.nsrc)
+        if args.version in [Options.VERSION_TWO, Options.VERSION_THREE]:
+            lm = np.empty(shape=slvr.lm_shape, dtype=slvr.lm_dtype)
+            l, m = lm[0,:], lm[1,:]
+            l[:] = 0.1
+            m[:] = 0.25
 
-        # Create 1Jy point sources
-        fI=slvr.ft(np.ones(slvr.ntime*slvr.nsrc)).reshape(slvr.ntime,slvr.nsrc)*2
-        fQ=slvr.ft(np.zeros(slvr.ntime*slvr.nsrc)).reshape(slvr.ntime,slvr.nsrc)
-        fU=slvr.ft(np.zeros(slvr.ntime*slvr.nsrc)).reshape(slvr.ntime,slvr.nsrc)
-        fV=slvr.ft(np.zeros(slvr.ntime*slvr.nsrc)).reshape(slvr.ntime,slvr.nsrc)
-        alpha=slvr.ft(np.ones(slvr.ntime*slvr.nsrc)).reshape(slvr.ntime,slvr.nsrc)*0.5
-        brightness = np.array([fI,fQ,fU,fV,alpha], dtype=slvr.ft)
+            slvr.transfer_lm(lm)
 
-        slvr.transfer_lm(lm)
-        slvr.transfer_brightness(brightness)
+            B = np.empty(shape=slvr.brightness_shape, dtype=slvr.brightness_dtype)
+            I, Q, U, V, alpha = B[0,:,:], B[1,:,:], B[2,:,:], B[3,:,:], B[4,:,:]
+            I[:] = 2
+            Q[:] = 1
+            U[:] = 1
+            V[:] = 1
+            alpha[:] = 0.5
+
+            slvr.transfer_brightness(B)
+        elif args.version in [Options.VERSION_FOUR, Options.VERSION_FIVE]:
+            lm = np.empty(shape=slvr.lm_shape, dtype=slvr.lm_dtype)
+            l, m = lm[:,0], lm[:,1]
+            l[:] = 0.1
+            m[:] = 0.25
+
+            slvr.transfer_lm(lm)
+
+            stokes = np.empty(shape=slvr.stokes_shape, dtype=slvr.stokes_dtype)
+            alpha = np.empty(shape=slvr.alpha_shape, dtype=slvr.alpha_dtype)
+            I, Q, U, V = stokes[:,:,0], stokes[:,:,1], stokes[:,:,2], stokes[:,:,3]
+            I[:] = 2
+            Q[:] = 1
+            U[:] = 1
+            V[:] = 1
+            alpha[:] = 0.5
+            slvr.transfer_stokes(stokes)
+            slvr.transfer_alpha(alpha)
 
         slvr.solve()
+
+        with slvr.context:
+            if args.version in [Options.VERSION_TWO, Options.VERSION_THREE]:
+                vis = slvr.vis_gpu.get().transpose(1, 2, 3, 0)
+            elif args.version in [Options.VERSION_FOUR, Options.VERSION_FIVE]:
+                vis = slvr.vis_gpu.get()
+
+            print vis
+            print vis.shape
 
         print slvr.X2

--- a/montblanc/impl/biro/v2/BiroSolver.py
+++ b/montblanc/impl/biro/v2/BiroSolver.py
@@ -69,7 +69,7 @@ P = [
     # on frequency, while we're dealing with wavelengths.
     prop_dict('gauss_scale', 'ft', fwhm2int*np.sqrt(2)*np.pi),
     prop_dict('two_pi', 'ft', 2*np.pi),
-    prop_dict('ref_wave', 'ft', 0.0),
+    prop_dict('ref_wave', 'ft', 1.5e9),
     prop_dict('sigma_sqrd', 'ft', 1.0),
     prop_dict('X2', 'ft', 0.0),
     prop_dict('beam_width', 'ft', 65),
@@ -140,9 +140,9 @@ A = [
 
     ary_dict('wavelength', ('nchan',), 'ft',
         default=lambda slvr, ary: montblanc.constants.C / \
-            np.linspace(1e-9, 2e-9, slvr.nchan),
+            np.linspace(1e9, 2e9, slvr.nchan),
         test=lambda slvr, ary: montblanc.constants.C / \
-            np.linspace(1e-9, 2e-9, slvr.nchan)),
+            np.linspace(1e9, 2e9, slvr.nchan)),
 
     ary_dict('point_errors', (2,'ntime','na'), 'ft',
         default=1,

--- a/montblanc/impl/biro/v2/BiroSolver.py
+++ b/montblanc/impl/biro/v2/BiroSolver.py
@@ -124,7 +124,7 @@ A = [
 
     ary_dict('lm', (2,'nsrc'), 'ft',
         default=0,
-        test=lambda slvr, ary: (rary(ary)-0.5)*1e-4),
+        test=lambda slvr, ary: (rary(ary)-0.5)*1e-1),
 
     ary_dict('brightness', (5,'ntime','nsrc'), 'ft',
         default=np.array([1,0,0,1,0.8])[:,np.newaxis,np.newaxis],
@@ -146,7 +146,7 @@ A = [
 
     ary_dict('point_errors', (2,'ntime','na'), 'ft',
         default=1,
-        test=lambda slvr, ary: (rary(ary)-0.5)*1e-5),
+        test=lambda slvr, ary: (rary(ary)-0.5)*1e-2),
 
     ary_dict('weight_vector', (4,'ntime','nbl','nchan'), 'ft',
         default=1,

--- a/montblanc/impl/biro/v4/BiroSolver.py
+++ b/montblanc/impl/biro/v4/BiroSolver.py
@@ -148,7 +148,7 @@ A = [
     # Source Definitions
     ary_dict('lm', ('nsrc',2), 'ft',
         default=0,
-        test=lambda slvr, ary: (rary(ary)-0.5) * 1e-4),
+        test=lambda slvr, ary: (rary(ary)-0.5) * 1e-1),
 
     ary_dict('stokes', ('nsrc','ntime', 4), 'ft',
         default=np.array([1,0,0,0])[np.newaxis,np.newaxis,:],
@@ -173,7 +173,7 @@ A = [
     # Beam
     ary_dict('point_errors', ('ntime','na','nchan',2), 'ft',
         default=0,
-        test=lambda slvr, ary: (rary(ary) - 0.5)*1e-5),
+        test=lambda slvr, ary: (rary(ary) - 0.5)*1e-2),
 
     ary_dict('antenna_scaling', ('na','nchan',2), 'ft',
         default=1,

--- a/montblanc/tests/test_biro_v2.py
+++ b/montblanc/tests/test_biro_v2.py
@@ -188,7 +188,7 @@ class TestBiroV2(unittest.TestCase):
         for p_slvr_cfg in src_perms(slvr_cfg, permute_weights=True):
             wv = p_slvr_cfg[Options.WEIGHT_VECTOR] 
             with solver(p_slvr_cfg) as slvr:
-                self.B_sum_test_impl(slvr, wv, {'rtol': 1e-3})
+                self.B_sum_test_impl(slvr, wv, {'rtol': 1e-2})
 
     def test_B_sum_double(self):
         """ Test the B sum double kernel """

--- a/montblanc/tests/test_biro_v4.py
+++ b/montblanc/tests/test_biro_v4.py
@@ -122,11 +122,10 @@ class TestBiroV4(unittest.TestCase):
         if cmp is None:
             cmp = {}
 
-        # In factory.py, our lm coordinates range from -5e-5 to 5e-5
-        # and pointing errors from -1e-5 to 1e-5. The following values
-        # make the beam cube sufficiently large to contain their
-        # values
-        S = 1e-4
+        # Make the beam cube sufficiently large to contain the
+        # test values for the lm and pointing error coordinates
+        # specified in BiroSolver.py
+        S = 1
 
         slvr.set_beam_ll(-S)
         slvr.set_beam_lm(-S)
@@ -166,8 +165,9 @@ class TestBiroV4(unittest.TestCase):
 
         # Test that at a decent proportion of
         # the calculated EKB terms are non-zero
-        non_zero = np.sum(ekb_cpu > 0) / float(ekb_cpu.size)
-        self.assertTrue(non_zero > 0.85,
+        non_zero = np.count_nonzero(ekb_cpu)
+        non_zero_ratio = non_zero / float(ekb_cpu.size)
+        self.assertTrue(non_zero_ratio > 0.85,
             'Non-zero EKB ratio is %f.' % non_zero)
 
     def test_EKBSqrt_float(self):
@@ -179,7 +179,7 @@ class TestBiroV4(unittest.TestCase):
             pipeline=Pipeline([RimeEBeam(), RimeBSqrt(), RimeEKBSqrt()]))
 
         with solver(slvr_cfg) as slvr:
-            self.EKBSqrt_test_impl(slvr, cmp={'rtol': 1e-5})
+            self.EKBSqrt_test_impl(slvr, cmp={'rtol': 1e-4})
 
     def test_EKBSqrt_double(self):
         """ Double precision EKBSqrt test """
@@ -227,6 +227,7 @@ class TestBiroV4(unittest.TestCase):
         # match each other
         chi_sqrd_sum_terms_cpu = slvr_cpu.compute_chi_sqrd_sum_terms(
             vis=gekb_vis_cpu, weight_vector=weight_vector)
+
         with slvr.context:
             chi_sqrd_sum_terms_gpu = slvr.chi_sqrd_result_gpu.get()
 
@@ -337,11 +338,10 @@ class TestBiroV4(unittest.TestCase):
         if cmp is None:
             cmp = {}
 
-        # In factory.py, our lm coordinates range from -5e-5 to 5e-5
-        # and pointing errors from -1e-5 to 1e-5. The following values
-        # make the beam cube sufficiently large to contain their
-        # values
-        S = 1e-4
+        # Make the beam cube sufficiently large to contain the
+        # test values for the lm and pointing error coordinates
+        # specified in BiroSolver.py
+        S = 1
 
         slvr.set_beam_ll(-S)
         slvr.set_beam_lm(-S)
@@ -390,9 +390,10 @@ class TestBiroV4(unittest.TestCase):
 
         # Test that at a decent proportion of
         # the calculated E terms are non-zero
-        non_zero_E = np.sum(E_term_cpu > 0) / float(E_term_cpu.size)
-        self.assertTrue(non_zero_E > 0.85,
-            'Non-zero E-term ratio is %f.' % non_zero_E)
+        non_zero_E = np.count_nonzero(E_term_cpu)
+        non_zero_E_ratio = non_zero_E / float(E_term_cpu.size)
+        self.assertTrue(non_zero_E_ratio > 0.85,
+            'Non-zero E-term ratio is {r}.'.format(r=non_zero_E_ratio))
 
     def test_E_beam_float(self):
         """ Test the E Beam float kernel """


### PR DESCRIPTION
Some test values produced large quantities of zeros, which are not useful for the purposes of comparison and testing. This pull request corrects this and makes other test values such as lm coordinates and pointing errors more representative.

The MS_test.py script has been updated so that v2 and v4 output can be compared. For example:

```bash
$ python MS_test.py some_ms.MS -v v2 > v2_output.txt
$ python MS_test.py some_ms.MS -v v4 > v4_output.txt
$ meld v2_output.txt v4_output.txt
```
