### PR TITLE
Fix v4 operation ordering and per antenna UVW values

### DIFF
--- a/montblanc/impl/biro/v2/gpu/RimeGaussBSum.py
+++ b/montblanc/impl/biro/v2/gpu/RimeGaussBSum.py
@@ -160,25 +160,27 @@ void rime_gauss_B_sum_impl(
         typename Tr::ct ant_two = jones_EK_scalar[i];
         // Get the complex scalar for antenna one and conjugate it
         i = (TIME*NA*NSRC + ANT1*NSRC + SRC)*NCHAN + CHAN;
-        typename Tr::ct ant_one = jones_EK_scalar[i]; ant_one.y = -ant_one.y;
+        typename Tr::ct ant_one = jones_EK_scalar[i];
+        ant_one.y = -ant_one.y;
 
-        // (a+bi)(c+di) = (ac-bd) + (ad+bc)i
-        // a = ant_two.x b=ant_two.y c=ant_one.x d = ant_one.y
-        typename Tr::ct value = Po::make_ct(
-            ant_two.x*ant_one.x - ant_two.y*ant_one.y,
-            ant_two.x*ant_one.y + ant_two.y*ant_one.x);
+        montblanc::complex_multiply_in_place<T>(ant_two, ant_one);
+        typename Tr::ct pol;
 
-        Isum.x += (I[threadIdx.z]+Q[threadIdx.z])*value.x + 0.0*value.y;
-        Isum.y += (I[threadIdx.z]+Q[threadIdx.z])*value.y + 0.0*value.x;
+        pol.x = I[threadIdx.z]+Q[threadIdx.z]; pol.y = 0;
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Isum.x += pol.x; Isum.y += pol.y;
 
-        Qsum.x += (I[threadIdx.z]-Q[threadIdx.z])*value.x - 0.0*value.y;
-        Qsum.y += (I[threadIdx.z]-Q[threadIdx.z])*value.y - 0.0*value.x;
+        pol.x = I[threadIdx.z]-Q[threadIdx.z]; pol.y = 0;
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Qsum.x += pol.x; Qsum.y += pol.y;
 
-        Usum.x += U[threadIdx.z]*value.x - -V[threadIdx.z]*value.y;
-        Usum.y += U[threadIdx.z]*value.y + -V[threadIdx.z]*value.x;
+        pol.x = U[threadIdx.z]; pol.y = -V[threadIdx.z];
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Usum.x += pol.x; Usum.y += pol.y;
 
-        Vsum.x += U[threadIdx.z]*value.x - V[threadIdx.z]*value.y;
-        Vsum.y += U[threadIdx.z]*value.y + V[threadIdx.z]*value.x;
+        pol.x = U[threadIdx.z]; pol.y = V[threadIdx.z];
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Vsum.x += pol.x; Vsum.y += pol.y;
 
         __syncthreads();
     }
@@ -222,25 +224,27 @@ void rime_gauss_B_sum_impl(
         ant_two.x *= exp; ant_two.y *= exp;
         // Get the complex scalar for antenna one and conjugate it
         i = (TIME*NA*NSRC + ANT1*NSRC + SRC)*NCHAN + CHAN;
-        typename Tr::ct ant_one = jones_EK_scalar[i]; ant_one.y = -ant_one.y;
+        typename Tr::ct ant_one = jones_EK_scalar[i];
+        ant_one.y = -ant_one.y;
 
-        // (a+bi)(c+di) = (ac-bd) + (ad+bc)i
-        // a = ant_two.x b=ant_two.y c=ant_one.x d = ant_one.y
-        typename Tr::ct value = Po::make_ct(
-            ant_two.x*ant_one.x - ant_two.y*ant_one.y,
-            ant_two.x*ant_one.y + ant_two.y*ant_one.x);
+        montblanc::complex_multiply_in_place<T>(ant_two, ant_one);
+        typename Tr::ct pol;
 
-        Isum.x += (I[threadIdx.z]+Q[threadIdx.z])*value.x + 0.0*value.y;
-        Isum.y += (I[threadIdx.z]+Q[threadIdx.z])*value.y + 0.0*value.x;
+        pol.x = I[threadIdx.z]+Q[threadIdx.z]; pol.y = 0;
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Isum.x += pol.x; Isum.y += pol.y;
 
-        Qsum.x += (I[threadIdx.z]-Q[threadIdx.z])*value.x - 0.0*value.y;
-        Qsum.y += (I[threadIdx.z]-Q[threadIdx.z])*value.y - 0.0*value.x;
+        pol.x = I[threadIdx.z]-Q[threadIdx.z]; pol.y = 0;
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Qsum.x += pol.x; Qsum.y += pol.y;
 
-        Usum.x += U[threadIdx.z]*value.x - -V[threadIdx.z]*value.y;
-        Usum.y += U[threadIdx.z]*value.y + -V[threadIdx.z]*value.x;
+        pol.x = U[threadIdx.z]; pol.y = -V[threadIdx.z];
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Usum.x += pol.x; Usum.y += pol.y;
 
-        Vsum.x += U[threadIdx.z]*value.x - V[threadIdx.z]*value.y;
-        Vsum.y += U[threadIdx.z]*value.y + V[threadIdx.z]*value.x;
+        pol.x = U[threadIdx.z]; pol.y = V[threadIdx.z];
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Vsum.x += pol.x; Vsum.y += pol.y;
 
         __syncthreads();
     }
@@ -287,25 +291,27 @@ void rime_gauss_B_sum_impl(
         ant_two.x *= sersic_factor; ant_two.y *= sersic_factor;
         // Get the complex scalar for antenna one and conjugate it
         i = (TIME*NA*NSRC + ANT1*NSRC + SRC)*NCHAN + CHAN;
-        typename Tr::ct ant_one = jones_EK_scalar[i]; ant_one.y = -ant_one.y;
+        typename Tr::ct ant_one = jones_EK_scalar[i];
+        ant_one.y = -ant_one.y;
 
-        // (a+bi)(c+di) = (ac-bd) + (ad+bc)i
-        // a = ant_two.x b=ant_two.y c=ant_one.x d = ant_one.y
-        typename Tr::ct value = Po::make_ct(
-            ant_two.x*ant_one.x - ant_two.y*ant_one.y,
-            ant_two.x*ant_one.y + ant_two.y*ant_one.x);
+        montblanc::complex_multiply_in_place<T>(ant_two, ant_one);
+        typename Tr::ct pol;
 
-        Isum.x += (I[threadIdx.z]+Q[threadIdx.z])*value.x + 0.0*value.y;
-        Isum.y += (I[threadIdx.z]+Q[threadIdx.z])*value.y + 0.0*value.x;
+        pol.x = I[threadIdx.z]+Q[threadIdx.z]; pol.y = 0;
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Isum.x += pol.x; Isum.y += pol.y;
 
-        Qsum.x += (I[threadIdx.z]-Q[threadIdx.z])*value.x - 0.0*value.y;
-        Qsum.y += (I[threadIdx.z]-Q[threadIdx.z])*value.y - 0.0*value.x;
+        pol.x = I[threadIdx.z]-Q[threadIdx.z]; pol.y = 0;
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Qsum.x += pol.x; Qsum.y += pol.y;
 
-        Usum.x += U[threadIdx.z]*value.x - -V[threadIdx.z]*value.y;
-        Usum.y += U[threadIdx.z]*value.y + -V[threadIdx.z]*value.x;
+        pol.x = U[threadIdx.z]; pol.y = -V[threadIdx.z];
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Usum.x += pol.x; Usum.y += pol.y;
 
-        Vsum.x += U[threadIdx.z]*value.x - V[threadIdx.z]*value.y;
-        Vsum.y += U[threadIdx.z]*value.y + V[threadIdx.z]*value.x;
+        pol.x = U[threadIdx.z]; pol.y = V[threadIdx.z];
+        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        Vsum.x += pol.x; Vsum.y += pol.y;
 
         __syncthreads();
     }

--- a/montblanc/impl/biro/v4/cpu/SolverCPU.py
+++ b/montblanc/impl/biro/v4/cpu/SolverCPU.py
@@ -42,15 +42,15 @@ class SolverCPU(object):
 
             # Calculate per baseline u from per antenna u
             u = slvr.uvw_cpu[:,:,0][ap]
-            u = ne.evaluate('ap-aq', {'ap': u[1], 'aq': u[0]})
+            u = ne.evaluate('ap-aq', {'ap': u[0], 'aq': u[1]})
 
             # Calculate per baseline v from per antenna v
             v = slvr.uvw_cpu[:,:,1][ap]
-            v = ne.evaluate('ap-aq', {'ap': v[1], 'aq': v[0]})
+            v = ne.evaluate('ap-aq', {'ap': v[0], 'aq': v[1]})
 
             # Calculate per baseline w from per antenna w
             w = slvr.uvw_cpu[:,:,2][ap]
-            w = ne.evaluate('ap-aq', {'ap': w[1], 'aq': w[0]})
+            w = ne.evaluate('ap-aq', {'ap': w[0], 'aq': w[1]})
 
             el = slvr.gauss_shape_cpu[0]
             em = slvr.gauss_shape_cpu[1]
@@ -93,15 +93,15 @@ class SolverCPU(object):
 
             # Calculate per baseline u from per antenna u
             u = slvr.uvw_cpu[:,:,0][ap]
-            u = ne.evaluate('ap-aq', {'ap': u[1], 'aq': u[0]})
+            u = ne.evaluate('ap-aq', {'ap': u[0], 'aq': u[1]})
 
             # Calculate per baseline v from per antenna v
             v = slvr.uvw_cpu[:,:,1][ap]
-            v = ne.evaluate('ap-aq', {'ap': v[1], 'aq': v[0]})
+            v = ne.evaluate('ap-aq', {'ap': v[0], 'aq': v[1]})
 
             # Calculate per baseline w from per antenna w
             w = slvr.uvw_cpu[:,:,2][ap]
-            w = ne.evaluate('ap-aq', {'ap': w[1], 'aq': w[0]})
+            w = ne.evaluate('ap-aq', {'ap': w[0], 'aq': w[1]})
 
             e1 = slvr.sersic_shape_cpu[0]
             e2 = slvr.sersic_shape_cpu[1]
@@ -538,7 +538,7 @@ class SolverCPU(object):
             assert ekb_sqrt_idx.shape == (2, slvr.nsrc, slvr.ntime, slvr.nbl, slvr.nchan, 4)
 
             result = self.jones_multiply_hermitian_transpose(
-                ekb_sqrt_idx[1], ekb_sqrt_idx[0],
+                ekb_sqrt_idx[0], ekb_sqrt_idx[1],
                 slvr.nsrc*slvr.ntime*slvr.nbl*slvr.nchan) \
                     .reshape(slvr.nsrc, slvr.ntime, slvr.nbl, slvr.nchan, 4)
 
@@ -618,12 +618,12 @@ class SolverCPU(object):
         assert g_term.shape == (2, slvr.ntime, slvr.nbl, slvr.nchan, 4)
 
         result = self.jones_multiply_hermitian_transpose(
-            g_term[1], ekb_vis,
+            g_term[0], ekb_vis,
             slvr.ntime*slvr.nbl*slvr.nchan) \
                 .reshape(slvr.ntime, slvr.nbl, slvr.nchan, 4)
 
         result = self.jones_multiply_hermitian_transpose(
-            result, g_term[0],
+            result, g_term[1],
             slvr.ntime*slvr.nbl*slvr.nchan) \
                 .reshape(slvr.ntime, slvr.nbl, slvr.nchan, 4)
 

--- a/montblanc/impl/biro/v4/cpu/SolverCPU.py
+++ b/montblanc/impl/biro/v4/cpu/SolverCPU.py
@@ -164,7 +164,7 @@ class SolverCPU(object):
 
             # e^(2*pi*sqrt(u*l+v*m+w*n)*frequency/C).
             # Dim. ntime x na x nchan x nsrcs
-            cplx_phase = ne.evaluate('exp(2*pi*1j*p*f/C)', {
+            cplx_phase = ne.evaluate('exp(-2*pi*1j*p*f/C)', {
                 'p': phase[:, :, :, np.newaxis],
                 'f': freq[np.newaxis, np.newaxis, np.newaxis, :],
                 'C': montblanc.constants.C,

--- a/montblanc/impl/biro/v4/gpu/RimeEKBSqrt.py
+++ b/montblanc/impl/biro/v4/gpu/RimeEKBSqrt.py
@@ -149,7 +149,7 @@ void rime_jones_EKBSqrt_impl(
             + s_uvw[threadIdx.z][threadIdx.y].y*s_lm.y
             + s_uvw[threadIdx.z][threadIdx.y].x*s_lm.x;
 
-        phase *= T(TWO_PI_OVER_C) * freq[threadIdx.x];
+        phase *= T(-TWO_PI_OVER_C) * freq[threadIdx.x];
 
         typename Tr::ct cplx_phase;
         Po::sincos(phase, &cplx_phase.y, &cplx_phase.x);

--- a/montblanc/impl/biro/v4/loaders/loaders.py
+++ b/montblanc/impl/biro/v4/loaders/loaders.py
@@ -43,11 +43,26 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         # Reshape the array and correct the axes
         ms_uvw = tm.getcol('UVW')
         assert ms_uvw.shape == uvw_shape, \
-            'MS UVW shape %s != expected %s' % (ms_uvw.shape,uvw_shape)
-        uvw_rec = solver.get_array_record('uvw')
-        uvw=np.empty(shape=uvw_rec.shape, dtype=uvw_rec.dtype)
-        uvw[:,1:na,:] = ms_uvw.reshape(ntime, nbl, 3) \
-            .astype(solver.ft)[:,:na-1,:]
+            'MS UVW shape %s != expected %s' % (ms_uvw.shape, uvw_shape)
+
+        # Create per antenna UVW coordinates.
+        # u_01 = u_0 - u_1
+        # u_02 = u_0 - u_2
+        # ...
+        # u_0N = u_0 - U_N
+        # where N = na - 1.
+
+        # We choose u_0 = 0 and thus have
+        # u_1 = -u_01
+        # u_2 = -u_02
+        # ...
+        # u_N = -u_0N
+
+        # Then, other baseline values can be derived as
+        # u_21 = u_2 - u_1
+        uvw = np.empty(shape=solver.uvw_shape, dtype=solver.uvw_dtype)
+        uvw[:,1:na,:] = -ms_uvw.reshape(ntime, nbl, 3)[:,:na-1,:] \
+            .astype(solver.ft)
         uvw[:,0,:] = solver.ft(0)
         solver.transfer_uvw(np.ascontiguousarray(uvw))
 


### PR DESCRIPTION
In v4, the phase Was previously calculated using `2*pi*1j`. It is now calculated with `-2*pi*1j`, which agrees with the RIME, and this pull request ensures that v2 and v4 visibilities are the same.

## Corrected per antenna UVW coordinate derivation in the loader

We have the following relation between antenna and baseline UVW coordinates. Working with the u
coordinate:

```
u_00 = u_0 - u_0
u_01 = u_0 - u_1
u_02 = u_0 - u_2
...
u_0N = u_0 - U_N
```

where N = na-1. Choosing u_0 = 0, we have:

```
u_0 = 0
u_1 = -u_01
u_2 = -u_02
...
u_N = -u_0N
```

Then, other baseline values can be derived as

```
u_21 = u_2 - u_1
```

## Corrected jones multiply and per baselines UVW coordinate calculation

Previously jones multiplication and per baseline UVW coordinates were calculated as follows:

```python
J_pq = dot(J_q, J_p^H)
u_pq = u_q - u_p
```

This has been corrected to:

```python
J_pq = dot(J_p, J_q^H)
u_pq = u_p - u_q
```

