### PR TITLE
Fix phase, uvw and jones multiplication calculations in v2.

### DIFF
--- a/montblanc/impl/biro/v2/cpu/SolverCPU.py
+++ b/montblanc/impl/biro/v2/cpu/SolverCPU.py
@@ -41,15 +41,15 @@ class SolverCPU(object):
 
             # Calculate per baseline u from per antenna u
             u = slvr.uvw_cpu[0][ap]
-            u = ne.evaluate('ap-aq', {'ap': u[1], 'aq': u[0]})
+            u = ne.evaluate('ap-aq', {'ap': u[0], 'aq': u[1]})
 
             # Calculate per baseline v from per antenna v
             v = slvr.uvw_cpu[1][ap]
-            v = ne.evaluate('ap-aq', {'ap': v[1], 'aq': v[0]})
+            v = ne.evaluate('ap-aq', {'ap': v[0], 'aq': v[1]})
 
             # Calculate per baseline w from per antenna w
             w = slvr.uvw_cpu[2][ap]
-            w = ne.evaluate('ap-aq', {'ap': w[1], 'aq': w[0]})
+            w = ne.evaluate('ap-aq', {'ap': w[0], 'aq': w[1]})
 
             el = slvr.gauss_shape_cpu[0]
             em = slvr.gauss_shape_cpu[1]
@@ -93,15 +93,15 @@ class SolverCPU(object):
 
             # Calculate per baseline u from per antenna u
             u = slvr.uvw_cpu[0][ap]
-            u = ne.evaluate('ap-aq', {'ap': u[1], 'aq': u[0]})
+            u = ne.evaluate('ap-aq', {'ap': u[0], 'aq': u[1]})
 
             # Calculate per baseline v from per antenna v
             v = slvr.uvw_cpu[1][ap]
-            v = ne.evaluate('ap-aq', {'ap': v[1], 'aq': v[0]})
+            v = ne.evaluate('ap-aq', {'ap': v[0], 'aq': v[1]})
 
             # Calculate per baseline w from per antenna w
             w = slvr.uvw_cpu[2][ap]
-            w = ne.evaluate('ap-aq', {'ap': w[1], 'aq': w[0]})
+            w = ne.evaluate('ap-aq', {'ap': w[0], 'aq': w[1]})
 
             e1 = slvr.sersic_shape_cpu[0]
             e2 = slvr.sersic_shape_cpu[1]
@@ -163,7 +163,7 @@ class SolverCPU(object):
 
             # e^(2*pi*sqrt(u*l+v*m+w*n)/wavelength).
             # Dim. na x ntime x nchan x nsrcs
-            phase = ne.evaluate('exp(2*pi*1j*p/wl)', {
+            phase = ne.evaluate('exp(-2*pi*1j*p/wl)', {
                 'p': phase[:, :, :, np.newaxis],
                 'wl': wave[np.newaxis, np.newaxis, np.newaxis, :],
                 'pi': np.pi
@@ -202,7 +202,7 @@ class SolverCPU(object):
             ap = slvr.get_ap_idx(src=True, chan=True)
             k_jones = self.compute_k_jones_scalar_per_ant()[ap]
 
-            k_jones_per_bl = k_jones[1]*k_jones[0].conj()
+            k_jones_per_bl = k_jones[0]*k_jones[1].conj()
 
             # Add in the shape terms of the gaussian sources.
             if slvr.ngsrc > 0:
@@ -277,7 +277,7 @@ class SolverCPU(object):
             ap = slvr.get_ap_idx(src=True, chan=True)
             e_jones = self.compute_e_jones_scalar_per_ant()[ap]
 
-            return e_jones[1]*e_jones[0].conj()
+            return e_jones[0]*e_jones[1].conj()
         except AttributeError as e:
             mbu.rethrow_attribute_exception(e)
 

--- a/montblanc/impl/biro/v2/gpu/RimeEK.py
+++ b/montblanc/impl/biro/v2/gpu/RimeEK.py
@@ -140,7 +140,7 @@ void rime_jones_EK_impl(
             + v[threadIdx.z][threadIdx.y]*m[0]
             + u[threadIdx.z][threadIdx.y]*l[0];
 
-        phase *= T(2.0) * Tr::cuda_pi / wl[threadIdx.x];
+        phase *= T(-2.0) * Tr::cuda_pi / wl[threadIdx.x];
 
         T real, imag;
         Po::sincos(phase, &imag, &real);

--- a/montblanc/impl/biro/v2/gpu/RimeGaussBSum.py
+++ b/montblanc/impl/biro/v2/gpu/RimeGaussBSum.py
@@ -154,32 +154,31 @@ void rime_gauss_B_sum_impl(
 
         __syncthreads();
 
-        // Get the complex scalars for antenna two and multiply
-        // in the exponent term
+        // Get the complex scalars for antenna two and conjugate it
         i = (TIME*NA*NSRC + ANT2*NSRC + SRC)*NCHAN + CHAN;
         typename Tr::ct ant_two = jones_EK_scalar[i];
-        // Get the complex scalar for antenna one and conjugate it
+        ant_two.y = - ant_two.y;
+        // Get the complex scalar for antenna one
         i = (TIME*NA*NSRC + ANT1*NSRC + SRC)*NCHAN + CHAN;
         typename Tr::ct ant_one = jones_EK_scalar[i];
-        ant_one.y = -ant_one.y;
 
-        montblanc::complex_multiply_in_place<T>(ant_two, ant_one);
+        montblanc::complex_multiply_in_place<T>(ant_one, ant_two);
         typename Tr::ct pol;
 
         pol.x = I[threadIdx.z]+Q[threadIdx.z]; pol.y = 0;
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Isum.x += pol.x; Isum.y += pol.y;
 
         pol.x = I[threadIdx.z]-Q[threadIdx.z]; pol.y = 0;
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Qsum.x += pol.x; Qsum.y += pol.y;
 
         pol.x = U[threadIdx.z]; pol.y = -V[threadIdx.z];
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Usum.x += pol.x; Usum.y += pol.y;
 
         pol.x = U[threadIdx.z]; pol.y = V[threadIdx.z];
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Vsum.x += pol.x; Vsum.y += pol.y;
 
         __syncthreads();
@@ -217,33 +216,33 @@ void rime_gauss_B_sum_impl(
         v1 *= T(GAUSS_SCALE)/wl[threadIdx.x];
         T exp = Po::exp(-(u1*u1 +v1*v1));
 
-        // Get the complex scalar for antenna two and multiply
-        // in the exponent term
+        // Get the complex scalars for antenna two,
+        // multiply in the exponent and conjugate it
         i = (TIME*NA*NSRC + ANT2*NSRC + SRC)*NCHAN + CHAN;
         typename Tr::ct ant_two = jones_EK_scalar[i];
         ant_two.x *= exp; ant_two.y *= exp;
-        // Get the complex scalar for antenna one and conjugate it
+        ant_two.y = - ant_two.y;
+        // Get the complex scalar for antenna one
         i = (TIME*NA*NSRC + ANT1*NSRC + SRC)*NCHAN + CHAN;
         typename Tr::ct ant_one = jones_EK_scalar[i];
-        ant_one.y = -ant_one.y;
 
-        montblanc::complex_multiply_in_place<T>(ant_two, ant_one);
+        montblanc::complex_multiply_in_place<T>(ant_one, ant_two);
         typename Tr::ct pol;
 
         pol.x = I[threadIdx.z]+Q[threadIdx.z]; pol.y = 0;
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Isum.x += pol.x; Isum.y += pol.y;
 
         pol.x = I[threadIdx.z]-Q[threadIdx.z]; pol.y = 0;
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Qsum.x += pol.x; Qsum.y += pol.y;
 
         pol.x = U[threadIdx.z]; pol.y = -V[threadIdx.z];
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Usum.x += pol.x; Usum.y += pol.y;
 
         pol.x = U[threadIdx.z]; pol.y = V[threadIdx.z];
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Vsum.x += pol.x; Vsum.y += pol.y;
 
         __syncthreads();
@@ -284,33 +283,33 @@ void rime_gauss_B_sum_impl(
         T sersic_factor = T(1.0) + u1*u1+v1*v1;
         sersic_factor = T(1.0) / (sersic_factor*Po::sqrt(sersic_factor));
 
-        // Get the complex scalar for antenna two and multiply
-        // in sersic factor term
+        // Get the complex scalars for antenna two,
+        // multiply in the exponent and conjugate it
         i = (TIME*NA*NSRC + ANT2*NSRC + SRC)*NCHAN + CHAN;
         typename Tr::ct ant_two = jones_EK_scalar[i];
         ant_two.x *= sersic_factor; ant_two.y *= sersic_factor;
-        // Get the complex scalar for antenna one and conjugate it
+        ant_two.y = - ant_two.y;
+        // Get the complex scalar for antenna one
         i = (TIME*NA*NSRC + ANT1*NSRC + SRC)*NCHAN + CHAN;
         typename Tr::ct ant_one = jones_EK_scalar[i];
-        ant_one.y = -ant_one.y;
 
-        montblanc::complex_multiply_in_place<T>(ant_two, ant_one);
+        montblanc::complex_multiply_in_place<T>(ant_one, ant_two);
         typename Tr::ct pol;
 
         pol.x = I[threadIdx.z]+Q[threadIdx.z]; pol.y = 0;
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Isum.x += pol.x; Isum.y += pol.y;
 
         pol.x = I[threadIdx.z]-Q[threadIdx.z]; pol.y = 0;
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Qsum.x += pol.x; Qsum.y += pol.y;
 
         pol.x = U[threadIdx.z]; pol.y = -V[threadIdx.z];
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Usum.x += pol.x; Usum.y += pol.y;
 
         pol.x = U[threadIdx.z]; pol.y = V[threadIdx.z];
-        montblanc::complex_multiply_in_place<T>(pol, ant_two);
+        montblanc::complex_multiply_in_place<T>(pol, ant_one);
         Vsum.x += pol.x; Vsum.y += pol.y;
 
         __syncthreads();


### PR DESCRIPTION
Previously jones multiplication, per baseline UVW coordinates and phase were calculated as follows in v2:

    J_pq = dot(J_q, J_p^H)
    u_pq = u_q - u_p
    cplx_phase = 2*np.pi*1j*...

This has been corrected to:

    J_pq = dot(J_p, J_q^H)
    u_pq = u_p - u_q
    cplx_phase = -2*np.pi*1j*...

This has no effect on the actual calculated visibilities, but corrects the operation ordering to agree with the RIME paper. See also #93.