### PR TITLE
Fix Hermitian Tranpose of Source Coherencies and baseline direction.

### DIFF
--- a/montblanc/impl/rime/v2/cpu/CPUSolver.py
+++ b/montblanc/impl/rime/v2/cpu/CPUSolver.py
@@ -52,15 +52,15 @@ class CPUSolver(MontblancNumpySolver):
 
         # Calculate per baseline u from per antenna u
         u = self.uvw[0][ap]
-        u = ne.evaluate('ap-aq', {'ap': u[0], 'aq': u[1]})
+        u = ne.evaluate('aq-ap', {'ap': u[0], 'aq': u[1]})
 
         # Calculate per baseline v from per antenna v
         v = self.uvw[1][ap]
-        v = ne.evaluate('ap-aq', {'ap': v[0], 'aq': v[1]})
+        v = ne.evaluate('aq-ap', {'ap': v[0], 'aq': v[1]})
 
         # Calculate per baseline w from per antenna w
         w = self.uvw[2][ap]
-        w = ne.evaluate('ap-aq', {'ap': w[0], 'aq': w[1]})
+        w = ne.evaluate('aq-ap', {'ap': w[0], 'aq': w[1]})
 
         el = self.gauss_shape[0]
         em = self.gauss_shape[1]
@@ -100,15 +100,15 @@ class CPUSolver(MontblancNumpySolver):
 
         # Calculate per baseline u from per antenna u
         u = self.uvw[0][ap]
-        u = ne.evaluate('ap-aq', {'ap': u[0], 'aq': u[1]})
+        u = ne.evaluate('aq-ap', {'ap': u[0], 'aq': u[1]})
 
         # Calculate per baseline v from per antenna v
         v = self.uvw[1][ap]
-        v = ne.evaluate('ap-aq', {'ap': v[0], 'aq': v[1]})
+        v = ne.evaluate('aq-ap', {'ap': v[0], 'aq': v[1]})
 
         # Calculate per baseline w from per antenna w
         w = self.uvw[2][ap]
-        w = ne.evaluate('ap-aq', {'ap': w[0], 'aq': w[1]})
+        w = ne.evaluate('aq-ap', {'ap': w[0], 'aq': w[1]})
 
         e1 = self.sersic_shape[0]
         e2 = self.sersic_shape[1]

--- a/montblanc/impl/rime/v2/gpu/RimeGaussBSum.py
+++ b/montblanc/impl/rime/v2/gpu/RimeGaussBSum.py
@@ -121,12 +121,12 @@ void rime_gauss_B_sum_impl(
     // UVW coordinates vary by baseline and time, but not channel
     if(threadIdx.x == 0)
     {
-        // UVW, calculated from u_pq = u_p - u_q
-        i = TIME*NA + ANT1;    u[threadIdx.z][threadIdx.y] = uvw[i];
+        // UVW, calculated from u_pq = u_q - u_p
+        i = TIME*NA + ANT2;    u[threadIdx.z][threadIdx.y] = uvw[i];
         i += NA*NTIME;         v[threadIdx.z][threadIdx.y] = uvw[i];
         i += NA*NTIME;         w[threadIdx.z][threadIdx.y] = uvw[i];
 
-        i = TIME*NA + ANT2;    u[threadIdx.z][threadIdx.y] -= uvw[i];
+        i = TIME*NA + ANT1;    u[threadIdx.z][threadIdx.y] -= uvw[i];
         i += NA*NTIME;         v[threadIdx.z][threadIdx.y] -= uvw[i];
         i += NA*NTIME;         w[threadIdx.z][threadIdx.y] -= uvw[i];
     }

--- a/montblanc/impl/rime/v2/loaders/loaders.py
+++ b/montblanc/impl/rime/v2/loaders/loaders.py
@@ -78,6 +78,21 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         assert ms_uvw.shape == uvw_shape, \
             'MS UVW shape %s != expected %s' % (ms_uvw.shape,uvw_shape)
 
+        # Create per antenna UVW coordinates.
+        # u_01 = u_1 - u_0
+        # u_02 = u_2 - u_0
+        # ...
+        # u_0N = u_N - U_0
+        # where N = na - 1.
+
+        # We choose u_0 = 0 and thus have
+        # u_1 = u_01
+        # u_2 = u_02
+        # ...
+        # u_N = u_0N
+
+        # Then, other baseline values can be derived as
+        # u_21 = u_1 - u_2
         uvw=np.empty(shape=solver.uvw_shape, dtype=solver.uvw_dtype)
         uvw[:,:,1:na] = ms_uvw.reshape(file_uvw_shape).transpose(uvw_transpose) \
             .astype(solver.ft)[:,:,:na-1]

--- a/montblanc/impl/rime/v4/cpu/CPUSolver.py
+++ b/montblanc/impl/rime/v4/cpu/CPUSolver.py
@@ -68,15 +68,15 @@ class CPUSolver(MontblancNumpySolver):
 
         # Calculate per baseline u from per antenna u
         u = self.uvw[:,:,0][ap]
-        u = ne.evaluate('ap-aq', {'ap': u[0], 'aq': u[1]})
+        u = ne.evaluate('aq-ap', {'ap': u[0], 'aq': u[1]})
 
         # Calculate per baseline v from per antenna v
         v = self.uvw[:,:,1][ap]
-        v = ne.evaluate('ap-aq', {'ap': v[0], 'aq': v[1]})
+        v = ne.evaluate('aq-ap', {'ap': v[0], 'aq': v[1]})
 
         # Calculate per baseline w from per antenna w
         w = self.uvw[:,:,2][ap]
-        w = ne.evaluate('ap-aq', {'ap': w[0], 'aq': w[1]})
+        w = ne.evaluate('aq-ap', {'ap': w[0], 'aq': w[1]})
 
         el = self.gauss_shape[0]
         em = self.gauss_shape[1]
@@ -116,15 +116,15 @@ class CPUSolver(MontblancNumpySolver):
 
         # Calculate per baseline u from per antenna u
         u = self.uvw[:,:,0][ap]
-        u = ne.evaluate('ap-aq', {'ap': u[0], 'aq': u[1]})
+        u = ne.evaluate('aq-ap', {'ap': u[0], 'aq': u[1]})
 
         # Calculate per baseline v from per antenna v
         v = self.uvw[:,:,1][ap]
-        v = ne.evaluate('ap-aq', {'ap': v[0], 'aq': v[1]})
+        v = ne.evaluate('aq-ap', {'ap': v[0], 'aq': v[1]})
 
         # Calculate per baseline w from per antenna w
         w = self.uvw[:,:,2][ap]
-        w = ne.evaluate('ap-aq', {'ap': w[0], 'aq': w[1]})
+        w = ne.evaluate('aq-ap', {'ap': w[0], 'aq': w[1]})
 
         e1 = self.sersic_shape[0]
         e2 = self.sersic_shape[1]
@@ -636,7 +636,7 @@ class CPUSolver(MontblancNumpySolver):
 
         assert g_term.shape == (2, ntime, nbl, nchan, 4)
 
-        result = (self.jones_multiply(g_term[0], ekb_vis, hermitian=True)
+        result = (self.jones_multiply(g_term[0], ekb_vis)
             .reshape(ntime, nbl, nchan, 4))
 
         result = (self.jones_multiply(result, g_term[1], hermitian=True)

--- a/montblanc/impl/rime/v4/gpu/RimeSumCoherencies.py
+++ b/montblanc/impl/rime/v4/gpu/RimeSumCoherencies.py
@@ -153,14 +153,14 @@ void rime_sum_coherencies_impl(
     if(threadIdx.x == 0)
     {
         // UVW, calculated from u_pq = u_p - u_q
-        i = TIME*NA + ANT1;
+        i = TIME*NA + ANT2;
         shared.uvw[threadIdx.z][threadIdx.y] = uvw[i];
 
-        i = TIME*NA + ANT2;
-        typename SumCohTraits<T>::UVWType ant2_uvw = uvw[i];
-        U -= ant2_uvw.x;
-        V -= ant2_uvw.y;
-        W -= ant2_uvw.z;
+        i = TIME*NA + ANT1;
+        typename SumCohTraits<T>::UVWType ant1_uvw = uvw[i];
+        U -= ant1_uvw.x;
+        V -= ant1_uvw.y;
+        W -= ant1_uvw.z;
     }
 
     // Wavelength varies by channel, but not baseline and time
@@ -313,7 +313,7 @@ void rime_sum_coherencies_impl(
     // Multiply the visibility by antenna 1's g term
     i = (TIME*NA + ANT1)*NPOLCHAN + POLCHAN;
     typename Tr::ct ant1_g_term = G_term[i];
-    montblanc::jones_multiply_4x4_hermitian_transpose_in_place<T>(ant1_g_term, polsum);
+    montblanc::jones_multiply_4x4_in_place<T>(ant1_g_term, polsum);
 
     // Multiply the visibility by antenna 2's g term
     i = (TIME*NA + ANT2)*NPOLCHAN + POLCHAN;

--- a/montblanc/impl/rime/v4/loaders/loaders.py
+++ b/montblanc/impl/rime/v4/loaders/loaders.py
@@ -60,22 +60,22 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
             'MS UVW shape %s != expected %s' % (ms_uvw.shape, uvw_shape)
 
         # Create per antenna UVW coordinates.
-        # u_01 = u_0 - u_1
-        # u_02 = u_0 - u_2
+        # u_01 = u_1 - u_0
+        # u_02 = u_2 - u_0
         # ...
-        # u_0N = u_0 - U_N
+        # u_0N = u_N - U_0
         # where N = na - 1.
 
         # We choose u_0 = 0 and thus have
-        # u_1 = -u_01
-        # u_2 = -u_02
+        # u_1 = u_01
+        # u_2 = u_02
         # ...
-        # u_N = -u_0N
+        # u_N = u_0N
 
         # Then, other baseline values can be derived as
-        # u_21 = u_2 - u_1
+        # u_21 = u_1 - u_2
         uvw = np.empty(shape=solver.uvw_shape, dtype=solver.uvw_dtype)
-        uvw[:,1:na,:] = -ms_uvw.reshape(ntime, nbl, 3)[:,:na-1,:] \
+        uvw[:,1:na,:] = ms_uvw.reshape(ntime, nbl, 3)[:,:na-1,:] \
             .astype(solver.ft)
         uvw[:,0,:] = solver.ft(0)
         solver.transfer_uvw(np.ascontiguousarray(uvw))

--- a/montblanc/impl/rime/v5/loaders/loaders.py
+++ b/montblanc/impl/rime/v5/loaders/loaders.py
@@ -218,21 +218,21 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
                 .reshape(t_end - t_start, nbl, 3))
 
             # Create per antenna UVW coordinates.
-            # u_01 = u_0 - u_1
-            # u_02 = u_0 - u_2
+            # u_01 = u_1 - u_0
+            # u_02 = u_2 - u_0
             # ...
-            # u_0N = u_0 - U_N
+            # u_0N = u_N - U_0
             # where N = na - 1.
 
             # We choose u_0 = 0 and thus have
-            # u_1 = -u_01
-            # u_2 = -u_02
+            # u_1 = u_01
+            # u_2 = u_02
             # ...
-            # u_N = -u_0N
+            # u_N = u_0N
 
             # Then, other baseline values can be derived as
-            # u_21 = u_2 - u_1
-            solver.uvw[t_start:t_end,1:na,:] = -uvw_buffer[:,:na-1,:]
+            # u_21 = u_1 - u_2
+            solver.uvw[t_start:t_end,1:na,:] = uvw_buffer[:,:na-1,:]
             solver.uvw[:,0,:] = 0
 
             if data_present:

--- a/montblanc/tests/test_rime_v4.py
+++ b/montblanc/tests/test_rime_v4.py
@@ -397,8 +397,14 @@ class TestRimeV4(unittest.TestCase):
         self.assertTrue(non_zero_E_ratio > 0.85,
             'Non-zero E-term ratio is {r}.'.format(r=non_zero_E_ratio))
 
-    def E_beam_test_helper(self, beam_lw, beam_mh, beam_nud, dtype):
-        slvr_cfg = montblanc.rime_solver_cfg(na=32, ntime=50, nchan=64,
+<<<<<<< HEAD
+    def E_beam_test_helper(self, beam_lw, beam_mh, beam_nud, dtype,
+            cmp=None):
+
+        if cmp is None:
+            cmp = {'rtol':1e-5}
+
+        slvr_cfg = BiroSolverConfiguration(na=32, ntime=50, nchan=64,
             sources=montblanc.sources(point=10, gaussian=10),
             beam_lw=beam_lw, beam_mh=beam_mh, beam_nud=beam_nud,
             dtype=dtype,
@@ -425,7 +431,7 @@ class TestRimeV4(unittest.TestCase):
 
         beam_lw, beam_mh, beam_nud = 1, 1, 1
         self.E_beam_test_helper(beam_lw, beam_mh, beam_nud,
-            Options.DTYPE_FLOAT)
+            Options.DTYPE_FLOAT,cmp={'rtol':1e-4})
 
     def test_E_beam_double(self):
         """ Test the E Beam double kernel """


### PR DESCRIPTION
Previously we had:
 - u_pq = u_p - u_q
 - V_pq = G_p X_pq^H G_q^H

This meant that the sign of our baseline and source coherencies were both incorrect,
but these produced the correct visibilities. For the sake of correct
notation, this has now been corrected to:
 - u_pq = u_q - u_p
 - V_pq = G_p X_pq G_q^H