### PR TITLE
Force integer conversion to remove warning

### DIFF
--- a/montblanc/src/montblanc/include/jones.cuh
+++ b/montblanc/src/montblanc/include/jones.cuh
@@ -24,9 +24,9 @@
 namespace montblanc {
 
 // The base visibility index. 0 0 0 0 4 4 4 4 8 8 8 8
-#define _MONTBLANC_VIS_BASE_IDX (cub::LaneId() & 28)
+#define _MONTBLANC_VIS_BASE_IDX int(cub::LaneId() & 28)
 // Odd polarisation? 0 1 0 1 0 1 0 1 0 1 0 1
-#define _MONTBLANC_IS_ODD_POL (cub::LaneId() & 0x1)
+#define _MONTBLANC_IS_ODD_POL int(cub::LaneId() & 0x1)
 // Even polarisation? 1 0 1 0 1 0 1 0 1 0 1 0
 #define _MONTBLANC_IS_EVEN_POL int(_MONTBLANC_IS_ODD_POL == 0)
 


### PR DESCRIPTION
Easy change, but historically it was non-trivial.
62e32fefc10f8f80ecfcc49209f6f19849acd3d7#diff-114574ff5aafce15d5473276b39e7c84
probably eased the fix.