### PR TITLE
Relax dtype requirements on user supplied arrays

### DIFF
--- a/montblanc/solvers/rime_solver.py
+++ b/montblanc/solvers/rime_solver.py
@@ -276,13 +276,6 @@ class RIMESolver(HyperCube):
                     "does not match the expected shape of '{es}'".format(
                         sn=k, ss=a.shape, es=expected_shape))
 
-            expected_dtype = reified_arrays[k].dtype
-
-            if a.dtype != expected_dtype:
-                raise TypeError("Supplied array '{sn}''s' dtype '{st}'' "
-                    "does not match the expected dtype of '{et}'".format(
-                        sn=k, st=a.dtype, et=expected_dtype))        
-
     def init_array(self, name, ary, value):
         # No defaults are supplied
         if value is None:

--- a/montblanc/tests/test_rime_v5.py
+++ b/montblanc/tests/test_rime_v5.py
@@ -107,18 +107,21 @@ class TestRimeV5(unittest.TestCase):
             with solver(slvr_cfg) as slvr:
                 pass
 
-        # Fall over on bad dtype
+        # Test that we can handle a single precision array
+        # on a double precision solver
+        visibilities = np.zeros(shape=(20,27*(27-1)//2,16,4), dtype=np.complex64)
         uvw = np.zeros(shape=(20,27,3), dtype=np.float32)
 
         slvr_cfg = montblanc.rime_solver_cfg(na=27, ntime=20, nchan=16,
             sources=montblanc.sources(point=10, gaussian=10, sersic=10),
             beam_lw=50, beam_mh=50, beam_nud=50,
             weight_vector=True, dtype=Options.DTYPE_DOUBLE,
-            array_cfg={'supplied' : {'uvw':uvw }})
+            array_cfg={'supplied' : {'model_vis':visibilities }})
 
-        with self.assertRaises(TypeError):
-            with solver(slvr_cfg) as slvr:
-                pass
+        with solver(slvr_cfg) as slvr:
+            self.assertTrue(slvr.model_vis.dtype == np.complex64)
+            self.assertTrue(slvr.observed_vis.dtype == np.complex128)
+            slvr.solve()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As data on the user or montblanc created solver arrays is copied into pinned memory created with the dtype of a GPU array, type conversion occurs automatically. Relax dtype requirements on user supplied arrays.