### PR TITLE
Allow visibilities to be overwritten or summed

### DIFF
--- a/montblanc/impl/rime/slvr_config.py
+++ b/montblanc/impl/rime/slvr_config.py
@@ -94,6 +94,18 @@ class RimeSolverConfig(SolverConfig):
         "Maximum number of visibility chunks that may be "
         "enqueued on a solver before throttling is applied.")
 
+    VISIBILITY_WRITE_MODE = 'vis_write'
+    VISIBILITY_WRITE_MODE_OVERWRITE = 'overwrite'
+    VISIBILITY_WRITE_MODE_SUM = 'sum'
+    DEFAULT_VISIBILITY_WRITE_MODE = VISIBILITY_WRITE_MODE_OVERWRITE
+    VISIBILITY_WRITE_MODE_DESCRIPTION = (
+        "If '{o}', model visibilities will be over-written. "
+        "If '{s}', model visibilities will be accumulated.").format(
+            o=VISIBILITY_WRITE_MODE_OVERWRITE,
+            s=VISIBILITY_WRITE_MODE_SUM)
+    VALID_VISIBILITY_WRITE_MODES = [VISIBILITY_WRITE_MODE_SUM,
+        VISIBILITY_WRITE_MODE_OVERWRITE]
+
     # RIME version
     VERSION = 'version'
     VERSION_ONE = 'v1'
@@ -129,6 +141,12 @@ class RimeSolverConfig(SolverConfig):
         VISIBILITY_THROTTLE_FACTOR: {
             SolverConfig.DESCRIPTION: VISIBILITY_THROTTLE_FACTOR_DESCRIPTION,
             SolverConfig.DEFAULT: DEFAULT_VISIBILITY_THROTTLE_FACTOR,
+            SolverConfig.REQUIRED: True
+        },
+
+        VISIBILITY_WRITE_MODE: {
+            SolverConfig.DESCRIPTION: VISIBILITY_WRITE_MODE_DESCRIPTION,
+            SolverConfig.DEFAULT: DEFAULT_VISIBILITY_WRITE_MODE,
             SolverConfig.REQUIRED: True
         },
 
@@ -216,6 +234,12 @@ class RimeSolverConfig(SolverConfig):
             type=int,
             help=self.VISIBILITY_THROTTLE_FACTOR_DESCRIPTION,
             default=self.DEFAULT_VISIBILITY_THROTTLE_FACTOR)
+
+        p.add_argument('--{v}'.format(v=self.VISIBILITY_WRITE_MODE),
+            required=False,
+            type=str,
+            help=self.VISIBILITY_WRITE_MODE_DESCRIPTION,
+            default=self.DEFAULT_VISIBILITY_WRITE_MODE)
 
         p.add_argument('--{v}'.format(v=self.VERSION),
             required=False,

--- a/montblanc/tests/test_rime_v5.py
+++ b/montblanc/tests/test_rime_v5.py
@@ -76,6 +76,39 @@ class TestRimeV5(unittest.TestCase):
             slvr.solve()
 
 
+    def test_visibility_write_mode(self):
+        """ Test visibility write mode """
+        slvr_cfg = montblanc.rime_solver_cfg(na=27, ntime=20, nchan=16,
+            sources=montblanc.sources(point=10, gaussian=10, sersic=10),
+            beam_lw=50, beam_mh=50, beam_nud=50,
+            weight_vector=True, dtype=Options.DTYPE_DOUBLE,
+            vis_write=Options.VISIBILITY_WRITE_MODE_OVERWRITE)
+
+        # Test that when the write mode is 'overwrite', multiple
+        # calls to solve produce the same model visibilities
+        with solver(slvr_cfg) as slvr:
+            slvr.solve()
+            vis = slvr.model_vis.copy()
+            slvr.solve()
+            assert np.allclose(vis, slvr.model_vis)
+
+        slvr_cfg = montblanc.rime_solver_cfg(na=27, ntime=20, nchan=16,
+            sources=montblanc.sources(point=10, gaussian=10, sersic=10),
+            beam_lw=50, beam_mh=50, beam_nud=50,
+            weight_vector=True, dtype=Options.DTYPE_DOUBLE,
+            vis_write=Options.VISIBILITY_WRITE_MODE_SUM)
+
+        # Test that when the write mode is 'sum', multiple
+        # calls to solve produce a summation of model visibilities
+        with solver(slvr_cfg) as slvr:
+            slvr.solve()
+            vis = slvr.model_vis.copy()
+            slvr.solve()
+            slvr.solve()
+            slvr.solve()
+            slvr.solve()
+            assert np.allclose(5*vis, slvr.model_vis)
+
     def test_array_supply(self):
         """ Test that its possible to supply a custom array to the solver """
         uvw = np.zeros(shape=(20,27,3), dtype=np.float64)


### PR DESCRIPTION
Provide an option to either:

- overwrite model visibilities. This is the default behaviour.
- accumulate them.