### PR TITLE
Implement computation of residuals

### DIFF
--- a/montblanc/impl/rime/slvr_config.py
+++ b/montblanc/impl/rime/slvr_config.py
@@ -94,17 +94,29 @@ class RimeSolverConfig(SolverConfig):
         "Maximum number of visibility chunks that may be "
         "enqueued on a solver before throttling is applied.")
 
+    VISIBILITY_OUTPUT = 'vis_output'
+    VISIBILITY_OUTPUT_MODEL = 'model'
+    VISIBILITY_OUTPUT_RESIDUALS = 'residuals'
+    DEFAULT_VISIBILITY_OUTPUT = VISIBILITY_OUTPUT_MODEL
+    VALID_VISIBILITY_OUTPUTS = [VISIBILITY_OUTPUT_MODEL,
+        VISIBILITY_OUTPUT_RESIDUALS]
+    VISIBILITY_OUTPUT_DESCRIPTION = (
+        "If '{m}' produces model visibilities. "
+        "If '{r}' produces residuals from the "
+        "difference of model and observed visibilities.").format(
+            m=VISIBILITY_OUTPUT_MODEL, r=VISIBILITY_OUTPUT_RESIDUALS)
+
     VISIBILITY_WRITE_MODE = 'vis_write_mode'
     VISIBILITY_WRITE_MODE_OVERWRITE = 'overwrite'
     VISIBILITY_WRITE_MODE_SUM = 'sum'
     DEFAULT_VISIBILITY_WRITE_MODE = VISIBILITY_WRITE_MODE_OVERWRITE
+    VALID_VISIBILITY_WRITE_MODES = [VISIBILITY_WRITE_MODE_SUM,
+        VISIBILITY_WRITE_MODE_OVERWRITE]
     VISIBILITY_WRITE_MODE_DESCRIPTION = (
         "If '{o}', model visibilities will be over-written. "
         "If '{s}', model visibilities will be accumulated.").format(
             o=VISIBILITY_WRITE_MODE_OVERWRITE,
             s=VISIBILITY_WRITE_MODE_SUM)
-    VALID_VISIBILITY_WRITE_MODES = [VISIBILITY_WRITE_MODE_SUM,
-        VISIBILITY_WRITE_MODE_OVERWRITE]
 
     # RIME version
     VERSION = 'version'
@@ -141,6 +153,12 @@ class RimeSolverConfig(SolverConfig):
         VISIBILITY_THROTTLE_FACTOR: {
             SolverConfig.DESCRIPTION: VISIBILITY_THROTTLE_FACTOR_DESCRIPTION,
             SolverConfig.DEFAULT: DEFAULT_VISIBILITY_THROTTLE_FACTOR,
+            SolverConfig.REQUIRED: True
+        },
+
+        VISIBILITY_OUTPUT: {
+            SolverConfig.DESCRIPTION: VISIBILITY_OUTPUT_DESCRIPTION,
+            SolverConfig.DEFAULT: DEFAULT_VISIBILITY_OUTPUT,
             SolverConfig.REQUIRED: True
         },
 
@@ -234,6 +252,13 @@ class RimeSolverConfig(SolverConfig):
             type=int,
             help=self.VISIBILITY_THROTTLE_FACTOR_DESCRIPTION,
             default=self.DEFAULT_VISIBILITY_THROTTLE_FACTOR)
+
+        p.add_argument('--{v}'.format(v=self.VISIBILITY_OUTPUT),
+            required=False,
+            type=str,
+            choices=self.VALID_VISIBILITY_OUTPUTS,
+            help=self.VISIBILITY_OUTPUT_DESCRIPTION,
+            default=self.DEFAULT_VISIBILITY_OUTPUT)
 
         p.add_argument('--{v}'.format(v=self.VISIBILITY_WRITE_MODE),
             required=False,

--- a/montblanc/solvers/rime_solver.py
+++ b/montblanc/solvers/rime_solver.py
@@ -70,6 +70,9 @@ class RIMESolver(HyperCube):
         # Is this solver handling auto-correlations
         self._is_auto_correlated = slvr_cfg.get(Options.AUTO_CORRELATIONS)
 
+        # Is this solver outputting visibilities or residuals
+        self._visibility_output = slvr_cfg.get(Options.VISIBILITY_OUTPUT)
+
     def is_float(self):
         return self.ft == np.float32
 
@@ -78,6 +81,12 @@ class RIMESolver(HyperCube):
 
     def use_weight_vector(self):
         return self._use_weight_vector
+
+    def outputs_model_visibilities(self):
+        return self._visibility_output == Options.VISIBILITY_OUTPUT_MODEL
+
+    def outputs_residuals(self):
+        return self._visibility_output == Options.VISIBILITY_OUTPUT_RESIDUALS
 
     def is_master(self):
         """ Is this a master solver """

--- a/montblanc/tests/test_cmp_vis.py
+++ b/montblanc/tests/test_cmp_vis.py
@@ -208,10 +208,10 @@ class TestCmpVis(unittest.TestCase):
             return vis.reshape(ntime, nbl, nchan, 4)
 
 
-    def get_v2_output(self, slvr_cfg):
-        slvr_cfg[Options.VERSION] = Options.VERSION_TWO
-
+    def get_v2_output(self, slvr_cfg, **kwargs):
         # Get visibilities from the v2 solver
+        slvr_cfg = slvr_cfg.copy()
+        slvr_cfg.update(**kwargs)
         slvr_cfg[Options.VERSION] = Options.VERSION_TWO
         with montblanc.rime_solver(slvr_cfg) as slvr:
             # Create and transfer lm to the solver
@@ -238,8 +238,10 @@ class TestCmpVis(unittest.TestCase):
 
             return slvr.X2, slvr.retrieve_model_vis().transpose(1,2,3,0)
 
-    def get_v4_output(self, slvr_cfg):
+    def get_v4_output(self, slvr_cfg, **kwargs):
         # Get visibilities from the v4 solver
+        slvr_cfg = slvr_cfg.copy()
+        slvr_cfg.update(**kwargs)
         slvr_cfg[Options.VERSION] = Options.VERSION_FOUR
         with montblanc.rime_solver(slvr_cfg) as slvr:
             # Create and transfer lm to the solver
@@ -268,8 +270,10 @@ class TestCmpVis(unittest.TestCase):
 
             return slvr.X2, slvr.retrieve_model_vis()
 
-    def get_v5_output(self, slvr_cfg):
+    def get_v5_output(self, slvr_cfg, **kwargs):
         # Get visibilities from the v5 solver
+        slvr_cfg = slvr_cfg.copy()
+        slvr_cfg.update(**kwargs)
         slvr_cfg[Options.VERSION] = Options.VERSION_FIVE
         with montblanc.rime_solver(slvr_cfg) as slvr:
             slvr.lm[:,0] = _L
@@ -299,6 +303,14 @@ class TestCmpVis(unittest.TestCase):
             sources=montblanc.sources(point=1, gaussian=0, sersic=0),
             dtype='double', version=Options.VERSION_TWO)
 
+        # Test the v4 and v5 residuals agree
+        v4_chi, v4_vis = self.get_v4_output(slvr_cfg,
+            vis_output=Options.VISIBILITY_OUTPUT_RESIDUALS)
+        v5_chi, v5_vis = self.get_v5_output(slvr_cfg,
+            vis_output=Options.VISIBILITY_OUTPUT_RESIDUALS)
+
+        self.assertTrue(np.allclose(v4_vis, v5_vis))
+        self.assertTrue(np.allclose(v4_chi, v5_chi))
 
         v2_chi, v2_vis = self.get_v2_output(slvr_cfg)
         v4_chi, v4_vis = self.get_v4_output(slvr_cfg)

--- a/montblanc/tests/test_rime_v4.py
+++ b/montblanc/tests/test_rime_v4.py
@@ -260,6 +260,20 @@ class TestRimeV4(unittest.TestCase):
                 self.sum_coherencies_test_impl(gpu_slvr, cpu_slvr,
                     cmp={'rtol': 1e-3})
 
+    def test_sum_coherencies_residuals_float(self):
+        """ Test computation of float residuals """
+        slvr_cfg = montblanc.rime_solver_cfg(na=14, ntime=20, nchan=48,
+            sources=montblanc.sources(point=10, gaussian=10),
+            dtype=Options.DTYPE_FLOAT,
+            pipeline=Pipeline([RimeSumCoherencies()]),
+            vis_output=Options.VISIBILITY_OUTPUT_RESIDUALS)
+
+        gpu_slvr, cpu_slvr = solvers(slvr_cfg)
+
+        with gpu_slvr, cpu_slvr:
+            self.sum_coherencies_test_impl(gpu_slvr, cpu_slvr,
+                cmp={'rtol': 1e-3})
+
     def test_sum_coherencies_double(self):
         """ Test the coherency sum double kernel """
         slvr_cfg = montblanc.rime_solver_cfg(na=14, ntime=20, nchan=48,
@@ -273,6 +287,19 @@ class TestRimeV4(unittest.TestCase):
 
             with gpu_slvr, cpu_slvr:
                 self.sum_coherencies_test_impl(gpu_slvr, cpu_slvr)
+
+    def test_sum_coherencies_residuals_double(self):
+        """ Test computation of double residuals """
+        slvr_cfg = montblanc.rime_solver_cfg(na=14, ntime=20, nchan=48,
+            sources=montblanc.sources(point=10, gaussian=10),
+            dtype=Options.DTYPE_DOUBLE,
+            pipeline=Pipeline([RimeSumCoherencies()]),
+            vis_output=Options.VISIBILITY_OUTPUT_RESIDUALS)
+
+        gpu_slvr, cpu_slvr = solvers(slvr_cfg)
+
+        with gpu_slvr, cpu_slvr:
+            self.sum_coherencies_test_impl(gpu_slvr, cpu_slvr)
 
     def B_sqrt_test_impl(self, gpu_slvr, cpu_slvr, cmp=None):
         """ Type independent implementation of the B square root test """


### PR DESCRIPTION
If the appropriate option is set on the solver, residuals will be output into the model visibility array.

```python
slvr_cfg = montblanc.rime_solver_cfg(...,
  vis_output=Options.VISIBILITY_OUTPUT_RESIDUALS,
  ...)
```
Model visibilities will always be output by default (`Options.VISIBILITY_OUTPUT_MODEL`)