### PR TITLE
Fix E beam interpolation

### DIFF
--- a/montblanc/impl/rime/v4/cpu/CPUSolver.py
+++ b/montblanc/impl/rime/v4/cpu/CPUSolver.py
@@ -416,22 +416,15 @@ class CPUSolver(MontblancNumpySolver):
         chan_low, chan_high = self.dim_extents('nchan')
         nchan_global = self.dim_global_size('nchan')
 
-        # Global channel size is divisor, but handle one channel case
-        div = self.ft(nchan_global-1) if nchan_global > 1 else 1.0
         # Create the channel range from the extents
-        chan_range = np.arange(chan_low, chan_high).astype(self.ft)
+        chan_range = np.arange(chan_low, chan_high).astype(np.float32)
         # Divide channel range by global size and multiply
         # to obtain position in the beam cube
-        chan = (beam_nud-1)*chan_range / div
+        chan = (np.float32(beam_nud-1)*chan_range /
+            np.float32(nchan_global))
         assert chan.shape == (chan_high - chan_low, )
         gchan = np.floor(chan)
         chd = (chan - gchan)[np.newaxis,np.newaxis,np.newaxis,:]
-
-        # Handle the boundary case where the channel
-        # lies on the last grid point
-        fiddle = (chan == beam_nud - 1)
-        gchan[fiddle] = beam_nud - 2
-        chd[:,:,:,fiddle] = 1
 
         # Initialise the sum to zero
         sum = np.zeros_like(self.jones)

--- a/montblanc/impl/rime/v4/gpu/RimeEBeam.py
+++ b/montblanc/impl/rime/v4/gpu/RimeEBeam.py
@@ -47,10 +47,6 @@ KERNEL_TEMPLATE = string.Template("""
 #include <montblanc/include/abstraction.cuh>
 #include <montblanc/include/brightness.cuh>
 
-#define BEAM_LW (${beam_lw})
-#define BEAM_MH (${beam_mh})
-#define BEAM_NUD (${beam_nud})
-
 #define BLOCKDIMX (${BLOCKDIMX})
 #define BLOCKDIMY (${BLOCKDIMY})
 #define BLOCKDIMZ (${BLOCKDIMZ})
@@ -63,21 +59,22 @@ KERNEL_TEMPLATE = string.Template("""
 // structure is declared. 
 ${rime_const_data_struct}
 __constant__ rime_const_data C;
-#define LEXT(name) C.name.lower_extent
-#define UEXT(name) C.name.upper_extent
+#define LEXT(name) (C.name.lower_extent)
+#define UEXT(name) (C.name.upper_extent)
 #define DEXT(name) (C.name.upper_extent - C.name.lower_extent)
-#define GLOBAL(name) C.name.global_size
+#define GLOBAL(name) (C.name.global_size)
+#define LOCAL(name) (C.name.local_size)
 
-#define NA (C.na.local_size)
-#define NBL (C.nbl.local_size)
-#define NCHAN (C.nchan.local_size)
-#define NTIME (C.ntime.local_size)
-#define NPSRC (C.npsrc.local_size)
-#define NGSRC (C.ngsrc.local_size)
-#define NSSRC (C.nssrc.local_size)
-#define NSRC (C.nnsrc.local_size)
-#define NPOL (C.npol.local_size)
-#define NPOLCHAN (C.npolchan.local_size)
+#define NA LOCAL(na)
+#define NBL LOCAL(nbl)
+#define NCHAN LOCAL(nchan)
+#define NTIME LOCAL(ntime)
+#define NSRC LOCAL(nsrc)
+#define NPOL LOCAL(npol)
+#define NPOLCHAN LOCAL(npolchan)
+#define BEAM_LW LOCAL(beam_lw)
+#define BEAM_MH LOCAL(beam_mh)
+#define BEAM_NUD LOCAL(beam_nud)
 
 template <
     typename T,

--- a/montblanc/tests/test_rime_v4.py
+++ b/montblanc/tests/test_rime_v4.py
@@ -456,9 +456,9 @@ class TestRimeV4(unittest.TestCase):
         self.E_beam_test_helper(beam_lw, beam_mh, beam_nud,
             Options.DTYPE_FLOAT)
 
-        beam_lw, beam_mh, beam_nud = 1, 1, 1
+        beam_lw, beam_mh, beam_nud = 2, 2, 2
         self.E_beam_test_helper(beam_lw, beam_mh, beam_nud,
-            Options.DTYPE_FLOAT,cmp={'rtol':1e-4})
+            Options.DTYPE_DOUBLE)
 
     def test_E_beam_double(self):
         """ Test the E Beam double kernel """
@@ -469,7 +469,7 @@ class TestRimeV4(unittest.TestCase):
         self.E_beam_test_helper(beam_lw, beam_mh, beam_nud,
             Options.DTYPE_DOUBLE)
 
-        beam_lw, beam_mh, beam_nud = 1, 1, 1
+        beam_lw, beam_mh, beam_nud = 2, 2, 2
         self.E_beam_test_helper(beam_lw, beam_mh, beam_nud,
             Options.DTYPE_DOUBLE)
 


### PR DESCRIPTION
- Use beam dimensions in constant memory instead of hardcoded #defines.
- Remove messy logic to handle single voxel cubes.

