### PR TITLE
Improve test case logging

### DIFF
--- a/montblanc/__init__.py
+++ b/montblanc/__init__.py
@@ -23,6 +23,7 @@ import os
 
 import montblanc.config
 
+from montblanc.logsetup import setup_logging, setup_test_logging
 from montblanc.tests import test
 from montblanc.version import __version__
 
@@ -33,49 +34,6 @@ def get_montblanc_path():
 
 def get_source_path():
     return os.path.join(get_montblanc_path(), 'src')
-
-def setup_logging():
-    """ Setup logging configuration """
-
-    import logging
-    import logging.handlers
-
-   # Console formatter
-    cfmt = logging.Formatter((
-        '%(name)s - '
-        '%(levelname)s - '
-        '%(message)s'))
-
-    # Console handler
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.INFO)
-    ch.setFormatter(cfmt)
-
-   # File formatter
-    cfmt = logging.Formatter((
-        '%(asctime)s - '
-        '%(levelname)s - '
-        '%(message)s'))
-
-    # File handler
-    fh = logging.handlers.RotatingFileHandler('montblanc.log',
-        maxBytes=10*1024*1024, backupCount=10)
-    fh.setLevel(logging.DEBUG)
-    fh.setFormatter(cfmt)
-
-    # Create the logger,
-    # adding the console and file handler
-    mb_logger = logging.getLogger('montblanc')
-    mb_logger.setLevel(logging.INFO)
-    mb_logger.addHandler(ch)
-    mb_logger.addHandler(fh)
-
-    # Set up the concurrent.futures logger
-    cf_logger = logging.getLogger('concurrent.futures')
-    cf_logger.setLevel(logging.INFO)
-    cf_logger.addHandler(ch)
-
-    return mb_logger
 
 log = setup_logging()
 

--- a/montblanc/logsetup.py
+++ b/montblanc/logsetup.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2015 Simon Perkins
+#
+# This file is part of montblanc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import logging.handlers
+
+def setup_logging():
+    """ Setup logging configuration """
+
+    # Console formatter, mention name
+    cfmt = logging.Formatter(('%(name)s - %(levelname)s - %(message)s'))
+
+    # File formatter, mention time
+    ffmt = logging.Formatter(('%(asctime)s - %(levelname)s - %(message)s'))
+
+    # Console handler
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.INFO)
+    ch.setFormatter(cfmt)
+
+    # File handler
+    fh = logging.handlers.RotatingFileHandler('montblanc.log',
+        maxBytes=10*1024*1024, backupCount=10)
+    fh.setLevel(logging.INFO)
+    fh.setFormatter(ffmt)
+
+    # Create the logger,
+    # adding the console and file handler
+    mb_logger = logging.getLogger('montblanc')
+    mb_logger.handlers = []
+    mb_logger.setLevel(logging.DEBUG)
+    mb_logger.addHandler(ch)
+    mb_logger.addHandler(fh)
+
+    # Set up the concurrent.futures logger
+    cf_logger = logging.getLogger('concurrent.futures')
+    cf_logger.setLevel(logging.DEBUG)
+    cf_logger.addHandler(ch)
+    cf_logger.addHandler(fh)
+
+    return mb_logger
+
+def setup_test_logging():
+    # Console formatter, mention name
+    cfmt = logging.Formatter(('%(name)s - %(levelname)s - %(message)s'))
+
+    # File formatter, mention time
+    ffmt = logging.Formatter(('%(asctime)s - %(levelname)s - %(message)s'))
+
+    # Only warnings and more serious stuff on the console
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.WARN)
+    ch.setFormatter(cfmt)
+
+    # Outputs DEBUG level logging to file
+    fh = logging.FileHandler('test.log')
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(ffmt)
+
+    # Set up the montblanc logger
+    mb_logger = logging.getLogger('montblanc')
+    mb_logger.handlers = []
+    mb_logger.setLevel(logging.DEBUG)
+    mb_logger.addHandler(ch)
+    mb_logger.addHandler(fh)
+
+    # Set up the concurrent.futures logger
+    cf_logger = logging.getLogger('concurrent.futures')
+    cf_logger.setLevel(logging.DEBUG)
+    cf_logger.addHandler(ch)
+    cf_logger.addHandler(fh)
+
+    return mb_logger

--- a/montblanc/pipeline.py
+++ b/montblanc/pipeline.py
@@ -123,11 +123,14 @@ class Pipeline:
             self.nr_of_executions += 1
 
         except PipeLineError:
-            montblanc.log.error('Pipeline Error occurred during RIME pipeline execution', exc_info=True)
+            montblanc.log.error("Pipeline Error occurred "
+                "during RIME pipeline execution",
+                exc_info=True)
             return False
         except Exception:
-            montblanc.log.error(('Unexpected exception occurred '
-                'during RIME pipeline execution'), exc_info=True)
+            montblanc.log.error("Unexpected exception occurred "
+                "during RIME pipeline execution",
+                exc_info=True)
             return False
 
         montblanc.log.debug('Execution of pipeline complete')

--- a/montblanc/tests/test_cmp_vis.py
+++ b/montblanc/tests/test_cmp_vis.py
@@ -103,15 +103,7 @@ class TestCmpVis(unittest.TestCase):
     def setUp(self):
         """ Set up each test case """
         np.random.seed(int(time.time()) & 0xFFFFFFFF)
-
-        # Add a handler that outputs INFO level logging to file
-        fh = logging.FileHandler('test.log')
-        fh.setLevel(logging.INFO)
-        ch = logging.StreamHandler()
-        ch.setLevel(logging.WARN)
-
-        montblanc.log.setLevel(logging.INFO)
-        montblanc.log.handlers = [fh, ch]
+        montblanc.setup_test_logging()
 
     def tearDown(self):
         """ Tear down each test case """

--- a/montblanc/tests/test_rime_solver.py
+++ b/montblanc/tests/test_rime_solver.py
@@ -46,13 +46,7 @@ class TestSolver(unittest.TestCase):
     def setUp(self):
         """ Set up each test case """
         np.random.seed(int(time.time()) & 0xFFFFFFFF)
-
-        # Add a handler that outputs INFO level logging to file
-        fh = logging.FileHandler('test.log')
-        fh.setLevel(logging.INFO)
-
-        montblanc.log.setLevel(logging.INFO)
-        montblanc.log.handlers = [fh]
+        montblanc.setup_test_logging()
 
     def tearDown(self):
         """ Tear down each test case """

--- a/montblanc/tests/test_rime_v2.py
+++ b/montblanc/tests/test_rime_v2.py
@@ -109,13 +109,7 @@ class TestRimeV2(unittest.TestCase):
     def setUp(self):
         """ Set up each test case """
         np.random.seed(int(time.time()) & 0xFFFFFFFF)
-
-        # Add a handler that outputs INFO level logging to file
-        fh = logging.FileHandler('test.log')
-        fh.setLevel(logging.INFO)
-
-        montblanc.log.setLevel(logging.INFO)
-        montblanc.log.handlers = [fh]
+        montblanc.setup_test_logging()
 
     def tearDown(self):
         """ Tear down each test case """

--- a/montblanc/tests/test_rime_v4.py
+++ b/montblanc/tests/test_rime_v4.py
@@ -114,13 +114,7 @@ class TestRimeV4(unittest.TestCase):
     def setUp(self):
         """ Set up each test case """
         np.random.seed(int(time.time()) & 0xFFFFFFFF)
-
-        # Add a handler that outputs INFO level logging to file
-        fh = logging.FileHandler('test.log')
-        fh.setLevel(logging.INFO)
-
-        montblanc.log.setLevel(logging.INFO)
-        montblanc.log.handlers = [fh]
+        montblanc.setup_test_logging()
 
     def tearDown(self):
         """ Tear down each test case """

--- a/montblanc/tests/test_rime_v5.py
+++ b/montblanc/tests/test_rime_v5.py
@@ -48,13 +48,7 @@ class TestRimeV5(unittest.TestCase):
     def setUp(self):
         """ Set up each test case """
         np.random.seed(int(time.time()) & 0xFFFFFFFF)
-
-        # Add a handler that outputs INFO level logging to file
-        fh = logging.FileHandler('test.log')
-        fh.setLevel(logging.INFO)
-
-        montblanc.log.setLevel(logging.INFO)
-        montblanc.log.handlers = [fh]
+        montblanc.setup_test_logging()
 
     def tearDown(self):
         """ Tear down each test case """

--- a/montblanc/tests/test_source_utils.py
+++ b/montblanc/tests/test_source_utils.py
@@ -37,13 +37,7 @@ class TestSourceUtils(unittest.TestCase):
     def setUp(self):
         """ Set up each test case """
         np.random.seed(int(time.time()) & 0xFFFFFFFF)
-
-        # Add a handler that outputs INFO level logging to file
-        fh = logging.FileHandler('test.log')
-        fh.setLevel(logging.INFO)
-
-        montblanc.log.setLevel(logging.INFO)
-        montblanc.log.handlers = [fh]
+        montblanc.setup_test_logging()
 
     def tearDown(self):
         """ Tear down each test case """

--- a/montblanc/tests/test_utils.py
+++ b/montblanc/tests/test_utils.py
@@ -39,13 +39,7 @@ class TestUtils(unittest.TestCase):
     def setUp(self):
         """ Set up each test case """
         np.random.seed(int(time.time()) & 0xFFFFFFFF)
-
-        # Add a handler that outputs INFO level logging to file
-        fh = logging.FileHandler('test.log')
-        fh.setLevel(logging.INFO)
-
-        montblanc.log.setLevel(logging.INFO)
-        montblanc.log.handlers = [fh]
+        montblanc.setup_test_logging()
 
     def tearDown(self):
         """ Tear down each test case """


### PR DESCRIPTION
Warnings and errors were not logged to the console, but to the test.log file instead. This has been improved by creating a standard test logging setup function.