### PR TITLE
Handle multiple frequency bands with equal number of channels

### DIFF
--- a/montblanc/examples/MS_single_node_example.py
+++ b/montblanc/examples/MS_single_node_example.py
@@ -73,10 +73,8 @@ if __name__ == '__main__':
         sources=montblanc.sources(point=args.npsrc,
             gaussian=args.ngsrc, sersic=args.nssrc),
         init_weights='weight', weight_vector=False,
-        dtype='double', auto_correlations=args.auto_correlations,
+        dtype='float', auto_correlations=args.auto_correlations,
         version=args.version)
-
-    print slvr_cfg
 
     with montblanc.rime_solver(slvr_cfg) as slvr:
         # Random point source coordinates in the l,m,n (brightness image) domain

--- a/montblanc/factory.py
+++ b/montblanc/factory.py
@@ -172,10 +172,12 @@ def create_rime_solver_from_ms(slvr_class_type, slvr_cfg):
     autocor = slvr_cfg.get(Options.AUTO_CORRELATIONS)
 
     with MeasurementSetLoader(msfile, auto_correlations=autocor) as loader:
-        ntime, na, nchan = loader.get_dims()
-        slvr_cfg[Options.NTIME] = ntime 
-        slvr_cfg[Options.NA] = na 
-        slvr_cfg[Options.NCHAN] = nchan 
+        ntime, nbl, na, nbands, nchan = loader.get_dims()
+        slvr_cfg[Options.NTIME] = ntime
+        slvr_cfg[Options.NA] = na
+        slvr_cfg[Options.NBL] = nbl
+        slvr_cfg[Options.NBANDS] = nbands
+        slvr_cfg[Options.NCHAN] = nchan
         slvr = slvr_class_type(slvr_cfg)
         loader.load(slvr, slvr_cfg)
         return slvr

--- a/montblanc/impl/rime/v2/config.py
+++ b/montblanc/impl/rime/v2/config.py
@@ -58,7 +58,6 @@ P = [
     # on frequency, while we're dealing with wavelengths.
     prop_dict('gauss_scale', 'ft', fwhm2int*np.sqrt(2)*np.pi),
     prop_dict('two_pi', 'ft', 2*np.pi),
-    prop_dict('ref_wave', 'ft', 1.5e9),
     prop_dict('sigma_sqrd', 'ft', 1.0),
     prop_dict('X2', 'ft', 0.0),
     prop_dict('beam_width', 'ft', 65),
@@ -137,6 +136,10 @@ A = [
             np.linspace(1e9, 2e9, slvr.dim_local_size('nchan')),
         test=lambda slvr, ary: montblanc.constants.C / \
             np.linspace(1e9, 2e9, slvr.dim_local_size('nchan'))),
+
+    ary_dict('ref_wavelength', ('nchan',), 'ft',
+        default=montblanc.constants.C / 1.4e9,
+        test=montblanc.constants.C / 1.4e9),
 
     ary_dict('point_errors', (2,'ntime','na'), 'ft',
         default=1,

--- a/montblanc/impl/rime/v2/cpu/CPUSolver.py
+++ b/montblanc/impl/rime/v2/cpu/CPUSolver.py
@@ -148,8 +148,6 @@ class CPUSolver(MontblancNumpySolver):
         """        
         nsrc, ntime, na, nchan = self.dim_local_size('nsrc', 'ntime', 'na', 'nchan')
 
-        wave = self.wavelength
-
         u, v, w = self.uvw[0], self.uvw[1], self.uvw[2]
         l, m = self.lm[0], self.lm[1]
         alpha = self.brightness[4]
@@ -167,7 +165,7 @@ class CPUSolver(MontblancNumpySolver):
         # Dim. na x ntime x nchan x nsrcs
         phase = ne.evaluate('exp(-2*pi*1j*p/wl)', {
             'p': phase[:, :, :, np.newaxis],
-            'wl': wave[np.newaxis, np.newaxis, np.newaxis, :],
+            'wl': self.wavelength[np.newaxis, np.newaxis, np.newaxis, :],
             'pi': np.pi
         })
 
@@ -177,8 +175,8 @@ class CPUSolver(MontblancNumpySolver):
         # when the other antenna term is multiplied with this one, we
         # end up with the full power term. sqrt(n)*sqrt(n) == n.
         power = ne.evaluate('(rw/wl)**(0.5*a)', {
-            'rw': self.ref_wave,
-            'wl': wave[np.newaxis, np.newaxis, :],
+            'rw': self.ref_wavelength[np.newaxis, np.newaxis, :],
+            'wl': self.wavelength[np.newaxis, np.newaxis, :],
             'a': alpha[:, :, np.newaxis]
         })
         assert power.shape == (ntime, nsrc, nchan)

--- a/montblanc/impl/rime/v4/config.py
+++ b/montblanc/impl/rime/v4/config.py
@@ -54,7 +54,6 @@ fwhm2int = 1.0/np.sqrt(np.log(256))
 P = [
     prop_dict('gauss_scale', 'ft', fwhm2int*np.sqrt(2)*np.pi/montblanc.constants.C),
     prop_dict('two_pi_over_c', 'ft', 2*np.pi/montblanc.constants.C),
-    prop_dict('ref_freq', 'ft', 1.5e9),
     prop_dict('sigma_sqrd', 'ft', 1.0),
     prop_dict('X2', 'ft', 0.0),
 
@@ -130,7 +129,7 @@ class Classifier(Enum):
 # List of arrays
 A = [
     # Input Arrays
-    ary_dict('uvw', ('ntime','na', 3), 'ft',
+    ary_dict('uvw', ('ntime', 'na', 3), 'ft',
         classifiers=frozenset([Classifier.EKB_SQRT_INPUT,
             Classifier.COHERENCIES_INPUT]),
         default=0,
@@ -152,6 +151,11 @@ A = [
             Classifier.COHERENCIES_INPUT]),
         default=lambda slvr, ary: np.linspace(1e9, 2e9, slvr.dim_local_size('nchan')),
         test=lambda slvr, ary: np.linspace(1e9, 2e9, slvr.dim_local_size('nchan'))),
+
+    ary_dict('ref_frequency', ('nchan',), 'ft',
+        classifiers=frozenset([Classifier.B_SQRT_INPUT]),
+        default=1.4e9,
+        test=1.4e9),
 
     # Holographic Beam
     ary_dict('point_errors', ('ntime','na','nchan',2), 'ft',

--- a/montblanc/impl/rime/v4/cpu/CPUSolver.py
+++ b/montblanc/impl/rime/v4/cpu/CPUSolver.py
@@ -252,7 +252,7 @@ class CPUSolver(MontblancNumpySolver):
 
             # Multiply the scalar power term into the matrix
             B_power = ne.evaluate('B*((f/rf)**a)', {
-                 'rf': self.ref_freq,
+                 'rf': self.ref_frequency[np.newaxis, np.newaxis, :, np.newaxis],
                  'B': B[:,:,np.newaxis,:],
                  'f': self.frequency[np.newaxis, np.newaxis, :, np.newaxis],
                  'a': self.alpha[:, :, np.newaxis, np.newaxis] })

--- a/montblanc/impl/rime/v5/gpu/RimeBSqrt.py
+++ b/montblanc/impl/rime/v5/gpu/RimeBSqrt.py
@@ -49,6 +49,5 @@ class RimeBSqrt(montblanc.impl.rime.v4.gpu.RimeBSqrt.RimeBSqrt):
         slvr = solver
 
         self.kernel(slvr.stokes, slvr.alpha,
-            slvr.frequency, slvr.B_sqrt,
-            slvr.ref_freq,
+            slvr.frequency, slvr.ref_frequency, slvr.B_sqrt,
             stream=stream, **self.launch_params)

--- a/montblanc/slvr_config.py
+++ b/montblanc/slvr_config.py
@@ -100,6 +100,11 @@ class SolverConfig(object):
     DEFAULT_NCHAN = 16
     NCHAN_DESCRIPTION = 'Channels'
 
+    # Number of bands
+    NBANDS = 'nbands'
+    DEFAULT_NBANDS = 1
+    NBANDS_DESCRIPTION = 'Bands'
+
     # Number of polarisations
     NPOL = 'npol'
     DEFAULT_NPOL = 4
@@ -203,6 +208,11 @@ class SolverConfig(object):
             DEFAULT: DEFAULT_NCHAN,
             REQUIRED: True },
 
+        NBANDS: {
+            DESCRIPTION: NBANDS_DESCRIPTION,
+            DEFAULT: DEFAULT_NBANDS,
+            REQUIRED: True },
+
         NPOL: {
             DESCRIPTION: NPOL_DESCRIPTION,
             DEFAULT: DEFAULT_NPOL,
@@ -286,6 +296,12 @@ class SolverConfig(object):
             type=int,
             help=self.NCHAN_DESCRIPTION,
             default=self.DEFAULT_NCHAN)
+
+        p.add_argument('--{v}'.format(v=self.NBANDS),
+            required=False,
+            type=int,
+            help=self.NBANDS_DESCRIPTION,
+            default=self.DEFAULT_NBANDS)
 
         p.add_argument('--{v}'.format(v=self.DTYPE),
             required=False,

--- a/montblanc/solvers/rime_solver.py
+++ b/montblanc/solvers/rime_solver.py
@@ -105,6 +105,7 @@ class RIMESolver(HyperCube):
         autocor = self._slvr_cfg.get(Options.AUTO_CORRELATIONS, False)
         ntime = self._slvr_cfg.get(Options.NTIME)
         na = self._slvr_cfg.get(Options.NA)
+        nbands = self._slvr_cfg.get(Options.NBANDS)
         nchan = self._slvr_cfg.get(Options.NCHAN)
         npol = self._slvr_cfg.get(Options.NPOL)
 
@@ -113,6 +114,8 @@ class RIMESolver(HyperCube):
             description=Options.NTIME_DESCRIPTION)
         self.register_dimension('na', na,
             description=Options.NA_DESCRIPTION)
+        self.register_dimension('nbands', nbands,
+            description=Options.NBANDS_DESCRIPTION)
         self.register_dimension('nchan', nchan,
             description=Options.NCHAN_DESCRIPTION)
         self.register_dimension(Options.NPOL, npol,

--- a/montblanc/tests/test_cmp_vis.py
+++ b/montblanc/tests/test_cmp_vis.py
@@ -224,7 +224,8 @@ class TestCmpVis(unittest.TestCase):
             slvr.transfer_brightness(B)
 
             # Set the reference wavelength
-            slvr.set_ref_wave(montblanc.constants.C / _REF_FREQ)
+            ref_wave = montblanc.constants.C / np.full(slvr.ref_wavelength.shape, _REF_FREQ)
+            slvr.transfer_ref_wavelength(ref_wave)
 
             slvr.solve()
 
@@ -256,7 +257,8 @@ class TestCmpVis(unittest.TestCase):
             slvr.transfer_alpha(alpha)
 
             # Set the reference frequency
-            slvr.set_ref_freq(_REF_FREQ)
+            ref_freq = np.full(slvr.ref_frequency.shape, _REF_FREQ)
+            slvr.transfer_ref_frequency(ref_freq)
 
             slvr.solve()
 
@@ -277,7 +279,7 @@ class TestCmpVis(unittest.TestCase):
             slvr.stokes[:,:,3] = _V
             slvr.alpha[:] = _ALPHA
 
-            slvr.set_ref_freq(_REF_FREQ)
+            slvr.ref_frequency[:] = _REF_FREQ
 
             slvr.solve()
 


### PR DESCRIPTION
Multiple frequency bands with equal channel numbers are now supported.
Each band's channels are stacked ontop of each other in the 'nchan' dimension,
thus nchan = nbands*nbandchan where nbandchan is the number of channels in a band.
There is now a reference wavelength/frequency per channel  (rather than per band)
as this makes the GPU code easier.

This change also modifies the loaders to support smaller baseline sizes
i.e. the requirement `nbl=na*(na-1)//2` is relaxed. However, variable baseline numbers
per timestep are not supported.