### PR TITLE
Support per-timestep parallactic angles for a given reference antenna

### DIFF
--- a/montblanc/impl/rime/v4/config.py
+++ b/montblanc/impl/rime/v4/config.py
@@ -64,7 +64,6 @@ P = [
     # Upper l and m coordinates of the beam cube
     prop_dict('beam_ul', 'ft', 0.5),
     prop_dict('beam_um', 'ft', 0.5),
-    prop_dict('parallactic_angle', 'ft', 0.0),
 ]
 
 def rand_uvw(slvr, ary):
@@ -128,7 +127,7 @@ class Classifier(Enum):
 
 # List of arrays
 A = [
-    # Input Arrays
+    # UVW coordinates
     ary_dict('uvw', ('ntime', 'na', 3), 'ft',
         classifiers=frozenset([Classifier.EKB_SQRT_INPUT,
             Classifier.COHERENCIES_INPUT]),
@@ -145,6 +144,7 @@ A = [
         default=lambda slvr, ary: slvr.default_ant_pairs()[1],
         test=lambda slvr, ary: slvr.default_ant_pairs()[1]),
 
+    # Frequency information
     ary_dict('frequency', ('nchan',), 'ft',
         classifiers=frozenset([Classifier.B_SQRT_INPUT,
             Classifier.EKB_SQRT_INPUT,
@@ -156,6 +156,12 @@ A = [
         classifiers=frozenset([Classifier.B_SQRT_INPUT]),
         default=1.4e9,
         test=1.4e9),
+
+    # Reference antenna parallactic angle at each timestep
+    ary_dict('parallactic_angles', ('ntime',), 'ft',
+        classifiers=frozenset(),
+        default=0,
+        test=lambda s, a: rary(a)*np.pi),
 
     # Holographic Beam
     ary_dict('point_errors', ('ntime','na','nchan',2), 'ft',

--- a/montblanc/impl/rime/v4/cpu/CPUSolver.py
+++ b/montblanc/impl/rime/v4/cpu/CPUSolver.py
@@ -373,8 +373,8 @@ class CPUSolver(MontblancNumpySolver):
             self.dim_local_size('nsrc', 'ntime', 'na', 'nchan',
                 'beam_lw', 'beam_mh', 'beam_nud'))
 
-        sint = np.sin(self.parallactic_angle*np.arange(ntime))
-        cost = np.cos(self.parallactic_angle*np.arange(ntime))
+        sint = np.sin(self.parallactic_angles)
+        cost = np.cos(self.parallactic_angles)
 
         assert sint.shape == (ntime,)
         assert cost.shape == (ntime,)

--- a/montblanc/impl/rime/v4/loaders/loaders.py
+++ b/montblanc/impl/rime/v4/loaders/loaders.py
@@ -22,11 +22,13 @@ import numpy as np
 import pyrap.tables as pt
 
 import montblanc
+import montblanc.util as mbu
 import montblanc.impl.common.loaders
 
 from montblanc.config import (RimeSolverConfig as Options)
 
 # Measurement Set string constants
+TIME = 'TIME'
 UVW = 'UVW'
 CHAN_FREQ = 'CHAN_FREQ'
 NUM_CHAN = 'NUM_CHAN'
@@ -41,6 +43,9 @@ WEIGHT = 'WEIGHT'
 SIGMA_SPECTRUM = 'SIGMA_SPECTRUM'
 SIGMA = 'SIGMA'
 
+POSITION = "POSITION"
+PHASE_DIR = 'PHASE_DIR'
+
 class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
     def load(self, solver, slvr_cfg):
         """
@@ -49,10 +54,10 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         tm = self.tables['main']
         ta = self.tables['ant']
         tf = self.tables['freq']
+        tfi = self.tables['field']
 
         ntime, na, nbl, nbands, nchan = solver.dim_global_size(
             'ntime', 'na', 'nbl', 'nbands', 'nchan')
-
 
         # Transfer frequencies
         freqs = (tf.getcol(CHAN_FREQ)
@@ -69,7 +74,8 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         # If the main table has visibilities for multiple bands, then
         # there will be multiple (duplicate) UVW, ANTENNA1 and ANTENNA2 values
         # Ensure uniqueness to get a single value here
-        uvw_table = pt.taql('SELECT FROM $tm ORDERBY UNIQUE TIME, ANTENNA1, ANTENNA2')
+        uvw_table = pt.taql("SELECT TIME, UVW, ANTENNA1, ANTENNA2 "
+            "FROM $tm ORDERBY UNIQUE TIME, ANTENNA1, ANTENNA2")
 
         # Check that we're getting the correct shape...
         uvw_shape = (ntime*nbl, 3)
@@ -108,6 +114,16 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         solver.transfer_antenna1(np.ascontiguousarray(ant1))
         solver.transfer_antenna2(np.ascontiguousarray(ant2))
 
+        # Compute parallactic angles
+        time_table = pt.taql('SELECT TIME FROM $tm ORDERBY UNIQUE TIME')
+        times = time_table.getcol(TIME)
+        ref_ant_position = ta.getcol(POSITION, startrow=0, nrow=1)[0]
+        phase_dir = tfi.getcol(PHASE_DIR)[0][0]
+
+        parallactic_angles = mbu.parallactic_angles(phase_dir, ref_ant_position, times)
+        solver.transfer_parallactic_angles(parallactic_angles)
+
+        time_table.close()
         uvw_table.close()
 
         # Load in visibility data, if it exists.

--- a/montblanc/impl/rime/v5/gpu/RimeEBeam.py
+++ b/montblanc/impl/rime/v5/gpu/RimeEBeam.py
@@ -48,10 +48,9 @@ class RimeEBeam(montblanc.impl.rime.v4.gpu.RimeEBeam.RimeEBeam):
     def execute(self, solver, stream=None):
         slvr = solver
 
-        self.kernel(slvr.lm,
+        self.kernel(slvr.lm, slvr.parallactic_angles,
             slvr.point_errors, slvr.antenna_scaling,
             slvr.E_beam, slvr.jones,
-            slvr.parallactic_angle,
             slvr.beam_ll, slvr.beam_lm,
             slvr.beam_ul, slvr.beam_um,
             stream=stream, **self.launch_params)

--- a/montblanc/impl/rime/v5/loaders/loaders.py
+++ b/montblanc/impl/rime/v5/loaders/loaders.py
@@ -24,11 +24,13 @@ import numpy as np
 import pyrap.tables as pt
 
 import montblanc
+import montblanc.util as mbu
 import montblanc.impl.common.loaders
 
 from montblanc.config import (RimeSolverConfig as Options)
 
 # Measurement Set string constants
+TIME = 'TIME'
 UVW = 'UVW'
 CHAN_FREQ = 'CHAN_FREQ'
 NUM_CHAN='NUM_CHAN'
@@ -42,6 +44,9 @@ WEIGHT_SPECTRUM = 'WEIGHT_SPECTRUM'
 WEIGHT = 'WEIGHT'
 SIGMA_SPECTRUM = 'SIGMA_SPECTRUM'
 SIGMA = 'SIGMA'
+
+POSITION = 'POSITION'
+PHASE_DIR = 'PHASE_DIR'
 
 WEIGHT_VECTOR = 'weight_vector'
 
@@ -149,6 +154,7 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         tm = self.tables['main']
         ta = self.tables['ant']
         tf = self.tables['freq']
+        tfi = self.tables['field']
 
         ntime, na, nbl, nchan, nbands, npol = solver.dim_global_size(
             'ntime', 'na', 'nbl', 'nchan', 'nbands', 'npol')
@@ -233,7 +239,8 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
         # If the main table has visibilities for multiple bands, then
         # there will be multiple (duplicate) UVW, ANTENNA1 and ANTENNA2 values
         # Ensure uniqueness to get a single value here
-        uvw_table = pt.taql('SELECT FROM $tm ORDERBY UNIQUE TIME, ANTENNA1, ANTENNA2')
+        uvw_table = pt.taql("SELECT TIME, UVW, ANTENNA1, ANTENNA2 "
+            "FROM $tm ORDERBY UNIQUE TIME, ANTENNA1, ANTENNA2")
         msrows = uvw_table.nrows()
         time_inc = 1
 
@@ -278,6 +285,18 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
             solver.uvw[t_start:t_end,1:na,:] = uvw_buffer[:,:na-1,:]
             solver.uvw[:,0,:] = 0
 
+        self.log('Computing parallactic angles')
+        # Compute parallactic angles
+        time_table = pt.taql('SELECT TIME FROM $tm ORDERBY UNIQUE TIME')
+        times = time_table.getcol(TIME)
+        ref_ant_position = ta.getcol(POSITION, startrow=0, nrow=1)[0]
+        phase_dir = tfi.getcol(PHASE_DIR)[0][0]
+
+        solver.parallactic_angles[:] = mbu.parallactic_angles(phase_dir, ref_ant_position, times)
+
+        time_table.close()
+        uvw_table.close()
+
         self.log("Processing frequency table {n}.".format(
             n=os.path.split(self.freqfile)[1]))
 
@@ -303,6 +322,9 @@ class MeasurementSetLoader(montblanc.impl.common.loaders.MeasurementSetLoader):
 
             # Next band
             band_ch0 += bs
+
+        self.log("Processing antenna table {n}.".format(
+            n=os.path.split(self.freqfile)[1]))
 
     def __enter__(solver):
         return super(MeasurementSetLoader,solver).__enter__()

--- a/montblanc/tests/test_rime_v4.py
+++ b/montblanc/tests/test_rime_v4.py
@@ -135,11 +135,6 @@ class TestRimeV4(unittest.TestCase):
         cpu_slvr.set_beam_ul(S)
         cpu_slvr.set_beam_um(S)
 
-        # Default parallactic angle is 0
-        # Set it to 1 degree so that our
-        # sources rotate through the cube.
-        cpu_slvr.set_parallactic_angle(np.deg2rad(1))
-
         copy_solver(cpu_slvr, gpu_slvr)
 
         # Call the GPU solver
@@ -374,10 +369,6 @@ class TestRimeV4(unittest.TestCase):
         cpu_slvr.set_beam_ul(S)
         cpu_slvr.set_beam_um(S)
 
-        # Default parallactic angle is 0
-        # Set it to 1 degree so that our
-        # sources rotate through the cube.
-        cpu_slvr.set_parallactic_angle(np.deg2rad(1))
         E_term_cpu = cpu_slvr.compute_E_beam()
 
         copy_solver(cpu_slvr, gpu_slvr)


### PR DESCRIPTION
Montblanc now has a parallactic_angles array with shape ('ntime',), containing the parallactic angles
at each timestep for a reference antenna with respect to the field phase centre. This is used to rotate sources within the beam cube at a particular timestep.