### PR TITLE
Classify parallactic_angles array for GPU copy

### DIFF
--- a/montblanc/impl/rime/v4/config.py
+++ b/montblanc/impl/rime/v4/config.py
@@ -159,7 +159,7 @@ A = [
 
     # Reference antenna parallactic angle at each timestep
     ary_dict('parallactic_angles', ('ntime',), 'ft',
-        classifiers=frozenset(),
+        classifiers=frozenset([Classifier.E_BEAM_INPUT]),
         default=0,
         test=lambda s, a: rary(a)*np.pi),
 


### PR DESCRIPTION
Classify the 'parallactic_angles' array to ensure that GPU copies occur prior to the E Beam kernel. This was missed in #146 .