### PR TITLE
Support reference frequencies per source

### DIFF
--- a/montblanc/impl/rime/tensorflow/config.py
+++ b/montblanc/impl/rime/tensorflow/config.py
@@ -219,6 +219,7 @@ STOKES_DESCRIPTION = ("(I,Q,U,V) Stokes parameters.")
 ALPHA_DESCRIPTION = ("Power term describing the distribution of a source's flux "
             "over frequency. Distribution is calculated as (nu/nu_ref)^alpha "
             "where nu is frequency.")
+REF_FREQ_DESCRIPTION = ("Reference frequency for {st} sources.")
 
 # Tag Description
 #
@@ -279,8 +280,7 @@ A = [
         description = "Index of the second antenna "
             "of the baseline pair."),
 
-    # Frequency and Reference Frequency arrays
-    # TODO: This is incorrect when channel local is not the same as channel global
+    # Frequency
     array_dict('frequency', ('nchan',), 'ft',
         default = lambda s, c: np.linspace(_freq_low, _freq_high,
                                 c.shape[0], dtype=c.dtype),
@@ -289,14 +289,6 @@ A = [
         tags    = "input",
         description = "Frequency. Frequencies from multiple bands "
             "are stacked on top of each other. ",
-        units   = HERTZ),
-
-    array_dict('ref_frequency', ('nchan',), 'ft',
-        default = lambda s, c: np.full(c.shape, _ref_freq, c.dtype),
-        test    = lambda s, c: np.full(c.shape, _ref_freq, c.dtype),
-        tags    = "input, constant",
-        description = "The reference frequency associated with the "
-            " channel's band.",
         units   = HERTZ),
 
     # Holographic Beam
@@ -388,6 +380,12 @@ A = [
         tags    = "input, constant",
         description = ALPHA_DESCRIPTION,
         units   = DIMENSIONLESS),
+    array_dict('point_ref_freq', ('npsrc',), 'ft',
+        default = lambda s, c: np.full(c.shape, _ref_freq, c.dtype),
+        test    = lambda s, c: np.full(c.shape, _ref_freq, c.dtype),
+        tags    = "input, constant",
+        description = REF_FREQ_DESCRIPTION.format(st="point"),
+        units   = HERTZ),
 
     # Gaussian Source Definitions
     array_dict('gaussian_lm', ('ngsrc',2), 'ft',
@@ -408,6 +406,12 @@ A = [
         tags    = "input, constant",
         description = ALPHA_DESCRIPTION,
         units   = DIMENSIONLESS),
+    array_dict('gaussian_ref_freq', ('ngsrc',), 'ft',
+        default = lambda s, c: np.full(c.shape, _ref_freq, c.dtype),
+        test    = lambda s, c: np.full(c.shape, _ref_freq, c.dtype),
+        tags    = "input, constant",
+        description = REF_FREQ_DESCRIPTION.format(st="gaussian"),
+        units   = HERTZ),
     array_dict('gaussian_shape', (3, 'ngsrc'), 'ft',
         default = default_gaussian_shape,
         test    = rand_gaussian_shape,
@@ -437,6 +441,12 @@ A = [
         tags    = "input, constant",
         description = ALPHA_DESCRIPTION,
         units   = DIMENSIONLESS),
+    array_dict('sersic_ref_freq', ('nssrc',), 'ft',
+        default = lambda s, c: np.full(c.shape, _ref_freq, c.dtype),
+        test    = lambda s, c: np.full(c.shape, _ref_freq, c.dtype),
+        tags    = "input, constant",
+        description = REF_FREQ_DESCRIPTION.format(st="sersic"),
+        units   = HERTZ),
     array_dict('sersic_shape', (3, 'nssrc'), 'ft',
         default = default_sersic_shape,
         test    = test_sersic_shape,

--- a/montblanc/impl/rime/tensorflow/rime_ops/b_sqrt_op_cpu.cpp
+++ b/montblanc/impl/rime/tensorflow/rime_ops/b_sqrt_op_cpu.cpp
@@ -32,7 +32,7 @@ auto bsqrt_shape_function = [](InferenceContext* c) {
         "frequency shape must be [nchan,] but is " + c->DebugString(frequency));
 
     TF_RETURN_WITH_CONTEXT_IF_ERROR(c->WithRank(ref_freq, 1, &input),
-        "ref_freq shape must be [nchan,] but is " + c->DebugString(ref_freq));
+        "ref_freq shape must be [nsrc,] but is " + c->DebugString(ref_freq));
 
     // bsqrt output is (nsrc, ntime, nchan, 4)
     ShapeHandle bsqrt = c->MakeShape({

--- a/montblanc/impl/rime/tensorflow/rime_ops/b_sqrt_op_cpu.h
+++ b/montblanc/impl/rime/tensorflow/rime_ops/b_sqrt_op_cpu.h
@@ -114,10 +114,11 @@ public:
                 {
                     // Compute square root of spectral index
                     FT psqrt = std::pow(
-                        frequency(chan)/ref_freq(chan),
+                        frequency(chan)/ref_freq(src),
                         alpha(src, time)*0.5);
 
-                    // Assign square root of the brightness matrix
+                    // Assign square root of the brightness matrix,
+                    // computed via cholesky decomposition
                     b_sqrt(src, time, chan, XX) = L00*psqrt;
                     b_sqrt(src, time, chan, XY) = 0.0;
                     b_sqrt(src, time, chan, YX) = L10*psqrt;

--- a/montblanc/impl/rime/tensorflow/rime_ops/test_b_sqrt.py
+++ b/montblanc/impl/rime/tensorflow/rime_ops/test_b_sqrt.py
@@ -34,8 +34,8 @@ def brightness_numpy(stokes, alpha, frequency, ref_freq):
     V = stokes[:,:,3].reshape(nsrc, ntime, 1)
 
     # Compute the spectral index
-    freq_ratio = (frequency/ref_freq)[np.newaxis,np.newaxis,:]
-    power = np.power(freq_ratio, alpha[:,:,np.newaxis])
+    freq_ratio = frequency[None,None,:]/ref_freq[:,None,None]
+    power = np.power(freq_ratio, alpha[:,:,None])
 
     # Compute the brightness matrix
     B = np.empty(shape=(nsrc, ntime, nchan, 4), dtype=ctype)
@@ -69,7 +69,7 @@ np_stokes[-1,-1,:] = 0
 
 np_alpha = np.random.random(size=(nsrc, ntime)).astype(dtype)*0.8
 np_frequency = np.linspace(1.3e9, 1.5e9, nchan, endpoint=True, dtype=dtype)
-np_ref_freq = np.full_like(np_frequency, 1.4e9)
+np_ref_freq = 0.2e9*np.random.random(size=(nsrc,)).astype(dtype) + 1.3e9
 
 # Create tensorflow arrays from the numpy arrays
 stokes = tf.Variable(np_stokes, name='stokes')


### PR DESCRIPTION
Previously, we used a reference frequency per band. Now, each source has a reference frequency associated with it.

- Removed `ref_frequency` data source.
- Added `point_ref_freq` data source.
- Added `gaussian_ref_freq` data source.
- Added `sersic_ref_freq` data source.

Confirmed this works with `test_meq_tf.py` with PR https://github.com/ska-sa/tigger/pull/84 applied to tigger.