### PR TITLE
Rename 'gterm' to 'direction_independent_effects'

### DIFF
--- a/montblanc/impl/rime/tensorflow/RimeSolver.py
+++ b/montblanc/impl/rime/tensorflow/RimeSolver.py
@@ -1061,7 +1061,7 @@ def _construct_tensorflow_expression(feed_data, device, shard):
 
         # Post process visibilities to produce model visibilites and chi squared
         model_vis, chi_squared = rime.post_process_visibilities(
-            D.antenna1, D.antenna2, D.gterm, D.flag,
+            D.antenna1, D.antenna2, D.direction_independent_effects, D.flag,
             D.weight, D.model_vis, summed_coherencies, D.observed_vis)
 
     # Create enstaging_area operation

--- a/montblanc/impl/rime/tensorflow/config.py
+++ b/montblanc/impl/rime/tensorflow/config.py
@@ -353,7 +353,7 @@ A = [
         units   = DIMENSIONLESS),
 
     # Direction-Independent Effects
-    array_dict('gterm', ('ntime', 'na', 'nchan', 'npol'), 'ct',
+    array_dict('direction_independent_effects', ('ntime', 'na', 'nchan', 'npol'), 'ct',
         default = identity_on_pols,
         test    = lambda s, c: rc(c.shape, c.dtype),
         tags    = "input, constant",

--- a/montblanc/impl/rime/tensorflow/rime_ops/post_process_visibilities_op_cpu.cpp
+++ b/montblanc/impl/rime/tensorflow/rime_ops/post_process_visibilities_op_cpu.cpp
@@ -29,16 +29,16 @@ auto shape_function = [](InferenceContext* c) {
         "antenna2 must have shape [ntime, nbl] but is " +
         c->DebugString(in_antenna2));
 
-    // TODO. Check shape and dimension sizes for 'gterm'
-    ShapeHandle in_gterm = c->input(2);
-    // Assert 'gterm' number of dimensions
-    TF_RETURN_WITH_CONTEXT_IF_ERROR(c->WithRank(in_gterm, 4, &input),
-        "gterm must have shape [ntime, na, nchan, 4] but is " +
-        c->DebugString(in_gterm));
-    // Assert 'gterm' dimension '3' size
-    TF_RETURN_WITH_CONTEXT_IF_ERROR(c->WithValue(c->Dim(in_gterm, 3), 4, &d),
-        "gterm must have shape [ntime, na, nchan, 4] but is " +
-        c->DebugString(in_gterm));
+    // TODO. Check shape and dimension sizes for 'direction_independent_effects'
+    ShapeHandle in_direction_independent_effects = c->input(2);
+    // Assert 'direction_independent_effects' number of dimensions
+    TF_RETURN_WITH_CONTEXT_IF_ERROR(c->WithRank(in_direction_independent_effects, 4, &input),
+        "direction_independent_effects must have shape [ntime, na, nchan, 4] but is " +
+        c->DebugString(in_direction_independent_effects));
+    // Assert 'direction_independent_effects' dimension '3' size
+    TF_RETURN_WITH_CONTEXT_IF_ERROR(c->WithValue(c->Dim(in_direction_independent_effects, 3), 4, &d),
+        "direction_independent_effects must have shape [ntime, na, nchan, 4] but is " +
+        c->DebugString(in_direction_independent_effects));
 
     // TODO. Check shape and dimension sizes for 'flag'
     ShapeHandle in_flag = c->input(3);
@@ -118,7 +118,7 @@ auto shape_function = [](InferenceContext* c) {
 REGISTER_OP("PostProcessVisibilities")
     .Input("antenna1: int32")
     .Input("antenna2: int32")
-    .Input("gterm: CT")
+    .Input("direction_independent_effects: CT")
     .Input("flag: uint8")
     .Input("weight: FT")
     .Input("base_vis: CT")

--- a/montblanc/impl/rime/tensorflow/rime_ops/post_process_visibilities_op_cpu.h
+++ b/montblanc/impl/rime/tensorflow/rime_ops/post_process_visibilities_op_cpu.h
@@ -40,7 +40,7 @@ public:
         // Create reference to input Tensorflow tensors
         const auto & in_antenna1 = context->input(0);
         const auto & in_antenna2 = context->input(1);
-        const auto & in_gterm = context->input(2);
+        const auto & in_direction_independent_effects = context->input(2);
         const auto & in_flag = context->input(3);
         const auto & in_weight = context->input(4);
         const auto & in_base_vis = context->input(5);
@@ -67,7 +67,7 @@ public:
         // Extract Eigen tensors
         auto antenna1 = in_antenna1.tensor<tensorflow::int32, 2>();
         auto antenna2 = in_antenna2.tensor<tensorflow::int32, 2>();
-        auto gterm = in_gterm.tensor<CT, 4>();
+        auto direction_independent_effects = in_direction_independent_effects.tensor<CT, 4>();
         auto flag = in_flag.tensor<tensorflow::uint8, 4>();
         auto weight = in_weight.tensor<FT, 4>();
         auto base_vis = in_base_vis.tensor<CT, 4>();
@@ -97,11 +97,11 @@ public:
                     CT mv2 = model_vis(time, bl, chan, 2);
                     CT mv3 = model_vis(time, bl, chan, 3);
 
-                    // Reference gterm for antenna 1
-                    const CT & a0 = gterm(time, ant1, chan, 0);
-                    const CT & a1 = gterm(time, ant1, chan, 1);
-                    const CT & a2 = gterm(time, ant1, chan, 2);
-                    const CT & a3 = gterm(time, ant1, chan, 3);
+                    // Reference direction_independent_effects for antenna 1
+                    const CT & a0 = direction_independent_effects(time, ant1, chan, 0);
+                    const CT & a1 = direction_independent_effects(time, ant1, chan, 1);
+                    const CT & a2 = direction_independent_effects(time, ant1, chan, 2);
+                    const CT & a3 = direction_independent_effects(time, ant1, chan, 3);
 
                     // Multiply model visibilities by antenna 1 g
                     CT r0 = a0*mv0 + a1*mv2;
@@ -110,10 +110,10 @@ public:
                     CT r3 = a2*mv1 + a3*mv3;
 
                     // Conjugate transpose of antenna 2 g term
-                    CT b0 = std::conj(gterm(time, ant2, chan, 0));
-                    CT b1 = std::conj(gterm(time, ant2, chan, 2));
-                    CT b2 = std::conj(gterm(time, ant2, chan, 1));
-                    CT b3 = std::conj(gterm(time, ant2, chan, 3));
+                    CT b0 = std::conj(direction_independent_effects(time, ant2, chan, 0));
+                    CT b1 = std::conj(direction_independent_effects(time, ant2, chan, 2));
+                    CT b2 = std::conj(direction_independent_effects(time, ant2, chan, 1));
+                    CT b3 = std::conj(direction_independent_effects(time, ant2, chan, 3));
 
                     // Multiply to produce model visibilities
                     mv0 = r0*b0 + r1*b2;

--- a/montblanc/impl/rime/tensorflow/rime_ops/test_post_process_visibilities.py
+++ b/montblanc/impl/rime/tensorflow/rime_ops/test_post_process_visibilities.py
@@ -44,7 +44,7 @@ class TestPostProcessVisibilities(unittest.TestCase):
             size=[ntime, nbl]).astype(np.int32)
         antenna2 = np.random.randint(low=0, high=na,
             size=[ntime, nbl]).astype(np.int32)
-        gterm = rc(size=[ntime, na, nchan, 4])
+        direction_independent_effects = rc(size=[ntime, na, nchan, 4])
         flag = np.random.randint(low=0, high=2,
             size=[ntime, nbl, nchan, 4]).astype(np.uint8)
         weight = rf(size=[ntime, nbl, nchan, 4])
@@ -53,11 +53,11 @@ class TestPostProcessVisibilities(unittest.TestCase):
         observed_vis = rc(size=[ntime, nbl, nchan, 4])
 
         # Argument list
-        np_args = [antenna1, antenna2, gterm, flag, weight,
+        np_args = [antenna1, antenna2, direction_independent_effects, flag, weight,
             base_vis, model_vis, observed_vis]
         # Argument string name list
-        arg_names = ['antenna1', 'antenna2', 'gterm', 'flag', 'weight',
-            'base_vis', 'model_vis', 'observed_vis']
+        arg_names = ['antenna1', 'antenna2', 'direction_independent_effects',
+            'flag', 'weight', 'base_vis', 'model_vis', 'observed_vis']
         # Constructor tensorflow variables
         tf_args = [tf.Variable(v, name=n) for v, n in zip(np_args, arg_names)]
 

--- a/montblanc/include/montblanc/abstraction.cuh
+++ b/montblanc/include/montblanc/abstraction.cuh
@@ -71,7 +71,7 @@ public:
     typedef int8_t sgn_brightness_type;
     typedef uint8_t flag_type;
     typedef float weight_type;
-    typedef float2 gterm_type;
+    typedef float2 die_type;
     typedef float2 vis_type;
 
 public:
@@ -221,7 +221,7 @@ public:
     typedef uint8_t flag_type;
     typedef int8_t sgn_brightness_type;
     typedef double weight_type;
-    typedef double2 gterm_type;
+    typedef double2 die_type;
     typedef double2 vis_type;
 
 


### PR DESCRIPTION
Direction Independent Effects better captures the generality of the data
source, as opposed to gterm which is confusing and could mean multiple
things (i.e. gains + feeds)