### PR TITLE
Add a Provider Initialisation Hook

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,25 @@
 API
 ===
 
-Source and Sink Contexts
-~~~~~~~~~~~~~~~~~~~~~~~~
+Contexts
+~~~~~~~~
+
+Contexts are objects supplying information to implementers of Providers.
+
+.. module:: montblanc.impl.rime.tensorflow.init_context
+
+.. autoclass:: InitialisationContext()
+    :members: cfg
+
+.. module:: montblanc.impl.rime.tensorflow.start_context
+
+.. autoclass:: StartContext()
+    :members: cube, cfg
+
+.. module:: montblanc.impl.rime.tensorflow.stop_context
+
+.. autoclass:: StopContext()
+    :members: cube, cfg
 
 .. module:: montblanc.impl.rime.tensorflow.sources.source_context
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 
@@ -304,7 +304,9 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['astropy', 'astropy.io',
-    'numpy', 'numexpr', 'pyrap',
-    'pyrap.tables', 'tensorflow']
+MOCK_MODULES = ['astropy', 'astropy.io', 'hypercube',
+    'numpy', 'numexpr',
+    'pyrap', 'pyrap.tables', 'pyrap.measures',
+    'tensorflow',
+    ]
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/montblanc/impl/rime/tensorflow/RimeSolver.py
+++ b/montblanc/impl/rime/tensorflow/RimeSolver.py
@@ -45,7 +45,7 @@ from .sources import (SourceContext, DefaultsSourceProvider)
 from .sinks import (SinkContext, NullSinkProvider)
 from .start_context import StartContext
 from .stop_context import StopContext
-
+from .init_context import InitialisationContext
 
 ONE_KB, ONE_MB, ONE_GB = 1024, 1024**2, 1024**3
 
@@ -584,6 +584,13 @@ class RimeSolver(MontblancTensorflowSolver):
 
         montblanc.log.info(src_provs_str)
         montblanc.log.info(snk_provs_str)
+
+        # Allow providers to initialise themselves based on
+        # the given configuration
+        ctx = InitialisationContext(self.config())
+
+        for p in itertools.chain(source_providers, sink_providers):
+            p.init(ctx)
 
         # Apply any dimension updates from the source provider
         # to the hypercube, taking previous reductions into account

--- a/montblanc/impl/rime/tensorflow/init_context.py
+++ b/montblanc/impl/rime/tensorflow/init_context.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2015 Simon Perkins
+#
+# This file is part of montblanc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+class InitialisationContext(object):
+    """
+    Initialisation Context object passed to Providers.
+
+    It provides initialisation information to a Provider,
+    allowing Providers to perform setup based on
+    configuration.
+
+    .. code-block:: python
+
+        class CustomSourceProvider(SourceProvider):
+            def init(self, init_context):
+                config = context.cfg()
+                ...
+    """
+    __slots__ = ('_cfg',)
+
+    def __init__(self, slvr_cfg):
+        self._cfg = slvr_cfg
+
+    @property
+    def cfg(self):
+        """
+        Configuration
+        """
+        return self._cfg
+
+    def help(self, display_cube=False):
+        """
+        Get help associated with this context
+
+        Returns
+        -------
+            str
+                A help string associated with this context
+        """
+        return """ Call context.cfg to access the solver configuration """

--- a/montblanc/impl/rime/tensorflow/sinks/sink_provider.py
+++ b/montblanc/impl/rime/tensorflow/sinks/sink_provider.py
@@ -26,6 +26,10 @@ class AbstractSinkProvider(object):
         """ Returns this data sink's name """
         raise NotImplementedError()
 
+    def init(self, init_context):
+        """ Called when initialising Providers """
+        raise NotImplementedError()
+
     def start(self, start_context):
         """ Called at the start of any solution """
         raise NotImplementedError()
@@ -69,6 +73,10 @@ def find_sinks(obj):
         if inspect.getargspec(m)[0] == SINK_ARGSPEC }
 
 class SinkProvider(AbstractSinkProvider):
+
+    def init(self, init_context):
+        """ Called when initialising Providers """
+        pass
 
     def start(self, start_context):
         """ Called at the start of any solution """

--- a/montblanc/impl/rime/tensorflow/sources/cached_source_provider.py
+++ b/montblanc/impl/rime/tensorflow/sources/cached_source_provider.py
@@ -100,6 +100,11 @@ class CachedSourceProvider(SourceProvider):
             else:
                 setattr(self, n, types.MethodType(ds, self))
 
+    def init(self, init_context):
+        """ Perform any initialisation required """
+        for p in self._providers:
+            p.init(init_context)
+
     def updated_dimensions(self):
         """ Update the dimensions """
         return [d for p in self._providers
@@ -117,11 +122,3 @@ class CachedSourceProvider(SourceProvider):
         with self._lock:
             return sum(a.nbytes for k, v in self._cache.iteritems()
                                 for a in v.itervalues())
-
-    def start(self, start_context):
-        if self._clear_start:
-            self.clear_cache()
-
-    def stop(self, stop_context):
-        if self._clear_stop:
-            self.clear_cache()

--- a/montblanc/impl/rime/tensorflow/sources/source_provider.py
+++ b/montblanc/impl/rime/tensorflow/sources/source_provider.py
@@ -26,6 +26,10 @@ class AbstractSourceProvider(object):
         """ Return the name associated with this data source """
         raise NotImplementedError()
 
+    def init(self, init_context):
+        """ Called when initialising Providers """
+        raise NotImplementedError()
+
     def start(self, start_context):
         """ Called at the start of any solution """
         raise NotImplementedError()
@@ -90,6 +94,9 @@ def find_sources(obj, argspec=None):
 
 class SourceProvider(AbstractSourceProvider):
 
+    def init(self, init_context):
+        """ Called when initialising Providers """
+        pass
 
     def start(self, start_context):
         """ Called at the start of any solution """

--- a/montblanc/impl/rime/tensorflow/start_context.py
+++ b/montblanc/impl/rime/tensorflow/start_context.py
@@ -37,7 +37,7 @@ class StartContext(object):
         ...
 
         class CustomSourceProvider(SourceProvider):
-            def start(self, context):
+            def start(self, start_context):
                 # Query dimensions directly
                 (lt, ut), (lb, ub) = context.dim_extents("ntime", "nbl")
                 ...

--- a/montblanc/impl/rime/tensorflow/stop_context.py
+++ b/montblanc/impl/rime/tensorflow/stop_context.py
@@ -36,7 +36,7 @@ class StopContext(object):
         ...
 
         class CustomSourceProvider(SourceProvider):
-            def stop(self, context):
+            def stop(self, stop_context):
                 # Query dimensions directly
                 (lt, ut), (lb, ub) = context.dim_extents("ntime", "nbl")
                 ...


### PR DESCRIPTION
Adds an `init` method hook to Providers.

```python
def init(self, init_context):
   config = init_context.cfg()
   self._initialise(config['feed_type'])
```
This gets invoked before all other provider logic and exists to let Providers perform any initialisation dependent on the Solver Configuration.