### PR TITLE
Choose feed type during fits lazy initialisation of FITS data

### DIFF
--- a/montblanc/tests/test_meq_tf.py
+++ b/montblanc/tests/test_meq_tf.py
@@ -62,9 +62,9 @@ with pt.table(msfile + '::SPECTRAL_WINDOW', ack=False) as SW:
 bandwidth = frequency[-1] - frequency[0]
 
 # Get filenames from pattern and open the files
-filenames = _create_filenames(beam_file_pattern)
+filenames = _create_filenames(beam_file_pattern, "linear")
 files = _open_fits_files(filenames)
-fgen = (f for (re, im) in files.itervalues() for f in (re, im))
+fgen = [f for (re, im) in files.itervalues() for f in (re, im)]
 
 # Set up the frequencies in each FITS file
 for file in fgen:


### PR DESCRIPTION
Lazily load linear/circular beam files

- The init(self, init_context) method now provides the ability to choose
  the filename correlation templates `['xx', 'xy', 'yx', 'yy']`/`['rr', 'rl', 'lr', 'll']`
 based on whether the feed type is  linear or circular.
- open FITS files and read FITS axis metadata in the init() method.