### PR TITLE
Support circular feeds

### DIFF
--- a/montblanc/impl/rime/tensorflow/rime_ops/circular_stokes_swap_op.h
+++ b/montblanc/impl/rime/tensorflow/rime_ops/circular_stokes_swap_op.h
@@ -1,0 +1,27 @@
+#ifndef RIME_CIRCULAR_STOKES_SWAP_OP_H
+#define RIME_CIRCULAR_STOKES_SWAP_OP_H
+
+// montblanc namespace start and stop defines
+#define MONTBLANC_NAMESPACE_BEGIN namespace montblanc {
+#define MONTBLANC_NAMESPACE_STOP }
+
+//  namespace start and stop defines
+#define MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_BEGIN namespace  {
+#define MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_STOP }
+
+MONTBLANC_NAMESPACE_BEGIN
+MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_BEGIN
+
+// General definition of the CircularStokesSwap op, which will be specialised in:
+//   - circular_stokes_swap_op_cpu.h for CPUs
+//   - circular_stokes_swap_op_gpu.cuh for CUDA devices
+// Concrete template instantions of this class are provided in:
+//   - circular_stokes_swap_op_cpu.cpp for CPUs
+//   - circular_stokes_swap_op_gpu.cu for CUDA devices
+template <typename Device, typename FT>
+class CircularStokesSwap {};
+
+MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_STOP
+MONTBLANC_NAMESPACE_STOP
+
+#endif // #ifndef RIME_CIRCULAR_STOKES_SWAP_OP_H

--- a/montblanc/impl/rime/tensorflow/rime_ops/circular_stokes_swap_op_cpu.cpp
+++ b/montblanc/impl/rime/tensorflow/rime_ops/circular_stokes_swap_op_cpu.cpp
@@ -1,0 +1,61 @@
+#include "circular_stokes_swap_op_cpu.h"
+
+#include "tensorflow/core/framework/shape_inference.h"
+
+MONTBLANC_NAMESPACE_BEGIN
+MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_BEGIN
+
+using tensorflow::shape_inference::InferenceContext;
+using tensorflow::shape_inference::ShapeHandle;
+using tensorflow::shape_inference::DimensionHandle;
+using tensorflow::Status;
+
+auto shape_function = [](InferenceContext* c) {
+    // Dummies for tests
+    ShapeHandle input;
+    DimensionHandle d;
+
+    // TODO. Check shape and dimension sizes for 'stokes_in'
+    ShapeHandle in_stokes_in = c->input(0);
+    // Assert 'stokes_in' number of dimensions
+    TF_RETURN_WITH_CONTEXT_IF_ERROR(c->WithRank(in_stokes_in, 3, &input),
+        "stokes_in must have shape [nsrc, ntime, 4] but is " +
+        c->DebugString(in_stokes_in));
+    // Assert 'stokes_in' dimension '2' size
+    TF_RETURN_WITH_CONTEXT_IF_ERROR(c->WithValue(c->Dim(in_stokes_in, 2), 4, &d),
+        "stokes_in must have shape [nsrc, ntime, 4] but is " +
+        c->DebugString(in_stokes_in));
+
+    c->set_output(0, in_stokes_in);
+    return Status::OK();
+};
+
+// Register the CircularStokesSwap operator.
+REGISTER_OP("CircularStokesSwap")
+    .Input("stokes_in: FT")
+    .Output("stokes_out: FT")
+    .Attr("FT: {float, double} = DT_FLOAT")
+    .Doc(R"doc(Swaps Stokes parameters around so that a circular brightness matrix is created, rather than a)doc")
+    .SetShapeFn(shape_function);
+
+
+// Register a CPU kernel for CircularStokesSwap
+// handling permutation ['float']
+REGISTER_KERNEL_BUILDER(
+    Name("CircularStokesSwap")
+    .TypeConstraint<float>("FT")
+    .Device(tensorflow::DEVICE_CPU),
+    CircularStokesSwap<CPUDevice, float>);
+
+// Register a CPU kernel for CircularStokesSwap
+// handling permutation ['double']
+REGISTER_KERNEL_BUILDER(
+    Name("CircularStokesSwap")
+    .TypeConstraint<double>("FT")
+    .Device(tensorflow::DEVICE_CPU),
+    CircularStokesSwap<CPUDevice, double>);
+
+
+
+MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_STOP
+MONTBLANC_NAMESPACE_STOP

--- a/montblanc/impl/rime/tensorflow/rime_ops/circular_stokes_swap_op_cpu.h
+++ b/montblanc/impl/rime/tensorflow/rime_ops/circular_stokes_swap_op_cpu.h
@@ -1,0 +1,68 @@
+#ifndef RIME_CIRCULAR_STOKES_SWAP_OP_CPU_H
+#define RIME_CIRCULAR_STOKES_SWAP_OP_CPU_H
+
+#include "circular_stokes_swap_op.h"
+
+// Required in order for Eigen::ThreadPoolDevice to be an actual type
+#define EIGEN_USE_THREADS
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+
+MONTBLANC_NAMESPACE_BEGIN
+MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_BEGIN
+
+// For simpler partial specialisation
+typedef Eigen::ThreadPoolDevice CPUDevice;
+
+// Specialise the CircularStokesSwap op for CPUs
+template <typename FT>
+class CircularStokesSwap<CPUDevice, FT> : public tensorflow::OpKernel
+{
+public:
+    explicit CircularStokesSwap(tensorflow::OpKernelConstruction * context) :
+        tensorflow::OpKernel(context) {}
+
+    void Compute(tensorflow::OpKernelContext * context) override
+    {
+        namespace tf = tensorflow;
+
+        // Create reference to input Tensorflow tensors
+        const auto & in_stokes_in = context->input(0);
+        
+        int nsrc = in_stokes_in.dim_size(0);
+        int ntime = in_stokes_in.dim_size(1);
+        int npol = in_stokes_in.dim_size(2);
+
+
+        // Extract Eigen tensors
+        auto stokes_in = in_stokes_in.tensor<FT, 3>();
+        
+
+        // Allocate output tensors
+        // Allocate space for output tensor 'stokes_out'
+        tf::Tensor * stokes_out_ptr = nullptr;
+        tf::TensorShape stokes_out_shape = tf::TensorShape({ nsrc, ntime, npol });
+        OP_REQUIRES_OK(context, context->allocate_output(
+            0, stokes_out_shape, &stokes_out_ptr));
+
+        auto stokes_out = stokes_out_ptr->tensor<FT, 3>();
+
+        #pragma omp parallel for collapse(2)
+        for(int src=0; src<nsrc; ++src)
+        {
+            for(int time=0; time<ntime; ++time)
+            {
+                stokes_out(src, time, 0) = stokes_in(src, time, 0);
+                stokes_out(src, time, 1) = stokes_in(src, time, 3);
+                stokes_out(src, time, 2) = stokes_in(src, time, 1);
+                stokes_out(src, time, 3) = stokes_in(src, time, 2);
+            }
+        }
+    }
+};
+
+MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_STOP
+MONTBLANC_NAMESPACE_STOP
+
+#endif // #ifndef RIME_CIRCULAR_STOKES_SWAP_OP_CPU_H

--- a/montblanc/impl/rime/tensorflow/rime_ops/circular_stokes_swap_op_gpu.cu
+++ b/montblanc/impl/rime/tensorflow/rime_ops/circular_stokes_swap_op_gpu.cu
@@ -1,0 +1,30 @@
+#if GOOGLE_CUDA
+
+#include "circular_stokes_swap_op_gpu.cuh"
+
+MONTBLANC_NAMESPACE_BEGIN
+MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_BEGIN
+
+
+// Register a GPU kernel for CircularStokesSwap
+// handling permutation ['float']
+REGISTER_KERNEL_BUILDER(
+    Name("CircularStokesSwap")
+    .TypeConstraint<float>("FT")
+    .Device(tensorflow::DEVICE_GPU),
+    CircularStokesSwap<GPUDevice, float>);
+
+// Register a GPU kernel for CircularStokesSwap
+// handling permutation ['double']
+REGISTER_KERNEL_BUILDER(
+    Name("CircularStokesSwap")
+    .TypeConstraint<double>("FT")
+    .Device(tensorflow::DEVICE_GPU),
+    CircularStokesSwap<GPUDevice, double>);
+
+
+
+MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_STOP
+MONTBLANC_NAMESPACE_STOP
+
+#endif // #if GOOGLE_CUDA

--- a/montblanc/impl/rime/tensorflow/rime_ops/circular_stokes_swap_op_gpu.cuh
+++ b/montblanc/impl/rime/tensorflow/rime_ops/circular_stokes_swap_op_gpu.cuh
@@ -1,0 +1,157 @@
+#if GOOGLE_CUDA
+
+#ifndef RIME_CIRCULAR_STOKES_SWAP_OP_GPU_CUH
+#define RIME_CIRCULAR_STOKES_SWAP_OP_GPU_CUH
+
+#include "circular_stokes_swap_op.h"
+#include <montblanc/abstraction.cuh>
+
+// Required in order for Eigen::GpuDevice to be an actual type
+#define EIGEN_USE_GPU
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+
+MONTBLANC_NAMESPACE_BEGIN
+MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_BEGIN
+
+// For simpler partial specialisation
+typedef Eigen::GpuDevice GPUDevice;
+
+// LaunchTraits struct defining
+// kernel block sizes for type permutations
+template <typename FT> struct LaunchTraits {};
+
+// Specialise for float
+// Should really be .cu file as this is a concrete type
+// but this works because this header is included only once
+template <> struct LaunchTraits<float>
+{
+    static constexpr int BLOCKDIMX = 1024;
+    static constexpr int BLOCKDIMY = 1;
+    static constexpr int BLOCKDIMZ = 1;
+
+    static dim3 block_size(int X, int Y, int Z)
+    {
+        return montblanc::shrink_small_dims(
+            dim3(BLOCKDIMX, BLOCKDIMY, BLOCKDIMZ),
+            X, Y, Z);
+    }
+};
+// Specialise for double
+// Should really be .cu file as this is a concrete type
+// but this works because this header is included only once
+template <> struct LaunchTraits<double>
+{
+    static constexpr int BLOCKDIMX = 1024;
+    static constexpr int BLOCKDIMY = 1;
+    static constexpr int BLOCKDIMZ = 1;
+
+    static dim3 block_size(int X, int Y, int Z)
+    {
+        return montblanc::shrink_small_dims(
+            dim3(BLOCKDIMX, BLOCKDIMY, BLOCKDIMZ),
+            X, Y, Z);
+    }
+};
+
+
+// The base stokes index. 0 0 0 0 4 4 4 4 8 8 8 8
+#define _MONTBLANC_STOKES_BASE_IDX int(cub::LaneId() & 28)
+
+// CUDA kernel outline
+template <typename FT>
+__global__ void rime_circular_stokes_swap(
+    const FT * stokes_in,
+    FT * stokes_out,
+    int nstokes, int npol)
+
+{
+    using LTr = LaunchTraits<FT>;
+
+    // Index into flattened stokes*pol array
+    int stokes_pol = blockIdx.x*blockDim.x + threadIdx.x;
+
+    // Thread guard
+    if(stokes_pol >= nstokes*npol)
+        { return; }
+
+    // Load in the polarisation
+    FT pol = stokes_in[stokes_pol];
+
+    // Get the polarisation index for this stokes parameter
+    int POL = stokes_pol & (npol-1);
+
+    // The following index shuffles [I Q U V] to [I V Q U]
+    int swap_index[4] = { 0, 3, 1, 2 };
+
+    // 0 3 1 2 4 7 5 6 8 11 9 10 ...
+    int shfl_idx = _MONTBLANC_STOKES_BASE_IDX + swap_index[POL];
+
+    // Write out shuffled polarisation
+    stokes_out[stokes_pol] = cub::ShuffleIndex(pol, shfl_idx);
+}
+
+// Specialise the CircularStokesSwap op for GPUs
+template <typename FT>
+class CircularStokesSwap<GPUDevice, FT> : public tensorflow::OpKernel
+{
+public:
+    explicit CircularStokesSwap(tensorflow::OpKernelConstruction * context) :
+        tensorflow::OpKernel(context) {}
+
+    void Compute(tensorflow::OpKernelContext * context) override
+    {
+        namespace tf = tensorflow;
+
+        // Create variables for input tensors
+        const auto & stokes_in = context->input(0);
+
+        int nsrc = stokes_in.dim_size(0);
+        int ntime = stokes_in.dim_size(1);
+        int npol = stokes_in.dim_size(2);
+        int nstokes = nsrc*ntime;
+
+        OP_REQUIRES(context, npol == 4,
+            tf::errors::InvalidArgument("Circular Stokes Swap given '", npol,
+                                        "' polarisations but can only handle 4 "
+                                        "at this point in time."));
+
+
+        // Allocate output tensors
+        // Allocate space for output tensor 'stokes_out'
+        tf::Tensor * stokes_out_ptr = nullptr;
+        tf::TensorShape stokes_out_shape = tf::TensorShape({ nsrc, ntime, npol });
+        OP_REQUIRES_OK(context, context->allocate_output(
+            0, stokes_out_shape, &stokes_out_ptr));
+
+
+        using LTr = LaunchTraits<FT>;
+
+        // Set up our CUDA thread block and grid
+        dim3 block(LTr::block_size(nstokes*npol, 1, 1));
+        dim3 grid(montblanc::grid_from_thread_block(
+            block, nstokes*npol, 1, 1));
+
+        // Get pointers to flattened tensor data buffers
+        const auto fin_stokes_in = stokes_in.flat<FT>().data();
+        auto fout_stokes_out = stokes_out_ptr->flat<FT>().data();
+
+
+        // Get the GPU device
+        const auto & device = context->eigen_device<GPUDevice>();
+
+        // Call the rime_circular_stokes_swap CUDA kernel
+        rime_circular_stokes_swap<FT>
+            <<<grid, block, 0, device.stream()>>>(
+                fin_stokes_in, fout_stokes_out,
+                nstokes, npol);
+    }
+};
+
+MONTBLANC_CIRCULAR_STOKES_SWAP_NAMESPACE_STOP
+MONTBLANC_NAMESPACE_STOP
+
+#endif // #ifndef RIME_CIRCULAR_STOKES_SWAP_OP_GPU_CUH
+
+#endif // #if GOOGLE_CUDA

--- a/montblanc/impl/rime/tensorflow/rime_ops/test_circular_stokes_swap.py
+++ b/montblanc/impl/rime/tensorflow/rime_ops/test_circular_stokes_swap.py
@@ -1,0 +1,65 @@
+import unittest
+
+import numpy as np
+import tensorflow as tf
+from tensorflow.python.client import device_lib
+
+class TestCircularStokesSwap(unittest.TestCase):
+    """ Tests the CircularStokesSwap operator """
+
+    def setUp(self):
+        # Load the rime operation library
+        from montblanc.impl.rime.tensorflow import load_tf_lib
+        self.rime = load_tf_lib()
+        # Obtain a list of GPU device specifications ['/gpu:0', '/gpu:1', ...]
+        self.gpu_devs = [d.name for d in device_lib.list_local_devices()
+                                if d.device_type == 'GPU']
+
+    def test_circular_stokes_swap(self):
+        """ Test the CircularStokesSwap operator """
+        # List of type constraint for testing this operator
+        type_permutations = [np.float32, np.float64]
+
+        # Run test with the type combinations above
+        for FT in type_permutations:
+            self._impl_test_circular_stokes_swap(FT)
+
+    def _impl_test_circular_stokes_swap(self, FT):
+        """ Implementation of the CircularStokesSwap operator test """
+
+        nsrc = 65
+        ntime = 33
+        npol = 4
+
+        # Create input variables
+        stokes = np.random.random(size=[nsrc, ntime, npol]).astype(FT)
+
+        # Argument list
+        np_args = [stokes]
+        # Argument string name list
+        arg_names = ['stokes']
+        # Constructor tensorflow variables
+        tf_args = [tf.Variable(v, name=n) for v, n in zip(np_args, arg_names)]
+
+        def _pin_op(device, *tf_args):
+            """ Pin operation to device """
+            with tf.device(device):
+                return self.rime.circular_stokes_swap(*tf_args)
+
+        # Pin operation to CPU
+        cpu_op = _pin_op('/cpu:0', *tf_args)
+
+        # Run the op on all GPUs
+        gpu_ops = [_pin_op(d, *tf_args) for d in self.gpu_devs]
+
+        # Initialise variables
+        init_op = tf.global_variables_initializer()
+
+        with tf.Session() as S:
+            S.run(init_op)
+            cpu_stokes = S.run(cpu_op)
+            for gpu_stokes in S.run(gpu_ops):
+                self.assertTrue(np.allclose(cpu_stokes, gpu_stokes))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/montblanc/impl/rime/tensorflow/sources/fits_beam_source_provider.py
+++ b/montblanc/impl/rime/tensorflow/sources/fits_beam_source_provider.py
@@ -361,7 +361,10 @@ class FitsBeamSourceProvider(SourceProvider):
 
     def init(self, init_context):
         """ Perform any initialisation """
-        self._initialise()
+
+        # Get the feed type, assuming linear
+        feed_type = init_context.cfg.get('feed_type', 'linear')
+        self._initialise(feed_type)
 
     def ebeam(self, context):
         """ ebeam cube data source """

--- a/montblanc/impl/rime/tensorflow/sources/fits_beam_source_provider.py
+++ b/montblanc/impl/rime/tensorflow/sources/fits_beam_source_provider.py
@@ -363,7 +363,7 @@ class FitsBeamSourceProvider(SourceProvider):
         """ Perform any initialisation """
 
         # Get the feed type, assuming linear
-        feed_type = init_context.cfg.get('feed_type', 'linear')
+        feed_type = init_context.cfg.get('polarisation_type', 'linear')
         self._initialise(feed_type)
 
     def ebeam(self, context):

--- a/montblanc/tests/test_meq_tf.py
+++ b/montblanc/tests/test_meq_tf.py
@@ -38,8 +38,8 @@ base_beam_file = os.path.join(beam_dir, beam_file_prefix)
 beam_file_pattern = ''.join((base_beam_file, '_$(corr)_$(reim).fits'))
 l_axis = '-X'
 
-# Feed type
-feed_type = 'linear'
+# Polarisation type
+pol_type = 'linear'
 
 # Find the location of the meqtree pipeliner script
 meqpipe_actual = subprocess.check_output(['which', meqpipe]).strip()
@@ -65,7 +65,7 @@ with pt.table(msfile + '::SPECTRAL_WINDOW', ack=False) as SW:
 bandwidth = frequency[-1] - frequency[0]
 
 # Get filenames from pattern and open the files
-filenames = _create_filenames(beam_file_pattern, feed_type)
+filenames = _create_filenames(beam_file_pattern, pol_type)
 files = _open_fits_files(filenames)
 fgen = [f for (re, im) in files.itervalues() for f in (re, im)]
 
@@ -292,7 +292,7 @@ slvr_cfg = montblanc.rime_solver_cfg(
     data_source=Options.DATA_SOURCE_DEFAULT,
     dtype='double' if dtype == np.float64 else 'float',
     auto_correlations=False,
-    feed_type=feed_type,
+    polarisation_type=pol_type,
     version='tf')
 
 slvr = montblanc.rime_solver(slvr_cfg)

--- a/montblanc/tests/test_meq_tf.py
+++ b/montblanc/tests/test_meq_tf.py
@@ -38,6 +38,9 @@ base_beam_file = os.path.join(beam_dir, beam_file_prefix)
 beam_file_pattern = ''.join((base_beam_file, '_$(corr)_$(reim).fits'))
 l_axis = '-X'
 
+# Feed type
+feed_type = 'linear'
+
 # Find the location of the meqtree pipeliner script
 meqpipe_actual = subprocess.check_output(['which', meqpipe]).strip()
 cfg_section = 'montblanc-compare'
@@ -62,7 +65,7 @@ with pt.table(msfile + '::SPECTRAL_WINDOW', ack=False) as SW:
 bandwidth = frequency[-1] - frequency[0]
 
 # Get filenames from pattern and open the files
-filenames = _create_filenames(beam_file_pattern, "linear")
+filenames = _create_filenames(beam_file_pattern, feed_type)
 files = _open_fits_files(filenames)
 fgen = [f for (re, im) in files.itervalues() for f in (re, im)]
 
@@ -289,6 +292,7 @@ slvr_cfg = montblanc.rime_solver_cfg(
     data_source=Options.DATA_SOURCE_DEFAULT,
     dtype='double' if dtype == np.float64 else 'float',
     auto_correlations=False,
+    feed_type=feed_type,
     version='tf')
 
 slvr = montblanc.rime_solver(slvr_cfg)


### PR DESCRIPTION
The solver can now be configured with a  `polarisation_type` argument, which can be set to either `'linear'` or `'circular'`. 

This will effect construction of:

1. The brightness matrix
2. The feed rotation matrix
3. The ebeam file schema, `['xx', 'xy', 'yx', 'yy']` vs `['rr', 'rl', 'lr', 'll']` for instance