### PR TITLE
Remove oneshot dimension updates on providers

### DIFF
--- a/montblanc/impl/rime/tensorflow/ms/ms_manager.py
+++ b/montblanc/impl/rime/tensorflow/ms/ms_manager.py
@@ -253,9 +253,6 @@ class MeasurementSetManager(object):
                     msr=oms.nrows(), ms=msname,
                     er=expected_rows, rd=row_desc, d=dim_desc))
 
-        # Have we indicated dimensions updates?
-        self._dim_updates_indicated = False
-
     def close(self):
         # Close all the tables
         for table in self._tables.itervalues():
@@ -274,11 +271,6 @@ class MeasurementSetManager(object):
         return self._nchanperband
 
     def updated_dimensions(self):
-        # Dimension updates bave been indicated, don't send them again
-        if self._dim_updates_indicated is True:
-            return ()
-
-        self._dim_updates_indicated = True
         return [(k, v) for k, v in self._dim_sizes.iteritems()]
 
     @property

--- a/montblanc/impl/rime/tensorflow/sources/fits_beam_source_provider.py
+++ b/montblanc/impl/rime/tensorflow/sources/fits_beam_source_provider.py
@@ -323,9 +323,6 @@ class FitsBeamSourceProvider(SourceProvider):
         # Have we initialised this object?
         self._initialised = False
 
-        # Have we already reported our dimensions?
-        self._dim_updates_indicated = False
-
     def _initialise(self, feed_type="linear"):
         """
         Initialise the object by generating appropriate filenames,
@@ -390,12 +387,6 @@ class FitsBeamSourceProvider(SourceProvider):
 
     def updated_dimensions(self):
         """ Indicate dimension sizes """
-
-        # Dimension updates have been indicated, don't send them again
-        if self._dim_updates_indicated is True:
-            return ()
-
-        self._dim_updates_indicated = True
         return self._dim_updates
 
     @property


### PR DESCRIPTION
Previously, the MS Manager and FITS Beam Source Provider only updated
dimension once. This does not work well with multiple instances of a
solver, so remove this.