### PR TITLE
Improve configuration error reporting.

### DIFF
--- a/montblanc/configuration.py
+++ b/montblanc/configuration.py
@@ -34,19 +34,20 @@ def config_validator():
             'type': 'string',
             'allowed': ['CPU', 'GPU'],
             'default': 'GPU',
-            '__description__': "Device to use by default." },
+            '__description__': "Default compute device." },
 
         'dtype': {
             'type': 'string',
             'allowed': ['float', 'double'],
             'default': 'double',
-            '__description__': "Floating Point precision of solution" },
+            '__description__': "Floating Point precision of "
+                                "inputs and solutions." },
 
         'auto_correlations': {
             'type': 'boolean',
             'default': False,
             '__description__': "Take auto-correlations into account "
-                               "when number of baselines "
+                               "when computing number of baselines "
                                "from number of antenna." },
 
         'polarisation_type': {
@@ -54,14 +55,15 @@ def config_validator():
             'allowed': ['linear', 'circular'],
             'default': 'linear',
             '__description__': "Type of polarisation. "
-                               "Can be 'linear' or 'circular'." },
+                               "Should be 'linear' or 'circular'." },
 
         'mem_budget': {
             'type': 'integer',
             'min': 1024,
             'default': 1024*1024*1024,
             '__description__': "Memory budget for solving a single "
-                               "tile of the problem on a CPU/GPU." },
+                               "tile of the problem on a CPU/GPU "
+                               "in bytes." },
 
         'source_batch_size': {
             'type': 'integer',


### PR DESCRIPTION
Describe invalid configuration values,
their position in the configuration schema,
and if available:

- Expected type.
- Allowed values.
- General description.

For example, the following:

```python
slvr_cfg = montblanc.rime_solver_cfg(
    mem_budget='cat',
    dtype='plort')
```

will produce this exception:

```python
ValueError: There were configuration errors:
Invalid configuration option cfg["dtype"] == 'plort'.
    Type must be 'string'.
    Allowed values are '['float', 'double']'.
    Description: Floating Point precision of inputs and solutions.
Invalid configuration option cfg["mem_budget"] == 'cat'.
    Type must be 'integer'.
    Description: Memory budget for solving a single tile of the
        problem on a CPU/GPU in bytes.
```