### PR TITLE
Smaller default beam dims

### DIFF
--- a/montblanc/impl/rime/tensorflow/RimeSolver.py
+++ b/montblanc/impl/rime/tensorflow/RimeSolver.py
@@ -1308,13 +1308,13 @@ def _setup_hypercube(cube, slvr_cfg):
     mbu.register_default_dimensions(cube, slvr_cfg)
 
     # Configure the dimensions of the beam cube
-    cube.register_dimension('beam_lw', 10,
+    cube.register_dimension('beam_lw', 2,
                             description='E Beam cube l width')
 
-    cube.register_dimension('beam_mh', 10,
+    cube.register_dimension('beam_mh', 2,
                             description='E Beam cube m height')
 
-    cube.register_dimension('beam_nud', 10,
+    cube.register_dimension('beam_nud', 2,
                             description='E Beam cube nu depth')
 
     # =========================================

--- a/montblanc/impl/rime/tensorflow/sinks/null_sink_provider.py
+++ b/montblanc/impl/rime/tensorflow/sinks/null_sink_provider.py
@@ -34,5 +34,12 @@ class NullSinkProvider(SinkProvider):
         montblanc.log.info("Received '{n}[{sl}]"
             .format(n=context.name, sl=slice_str))
 
+    def chi_squared(self, context):
+        array_schema = context.array(context.name)
+        slices = context.slice_index(*array_schema.shape)
+        slice_str = ','.join('%s:%s' % (s.start, s.stop) for s in slices)
+        montblanc.log.info("Received '{n}[{sl}]"
+            .format(n=context.name, sl=slice_str))
+
     def __str__(self):
         return self.__class__.__name__


### PR DESCRIPTION
Use smallest possible size for default beam dims

Intention here is to make the entire default beam fit within cache so that evaluation of it is as fast as possible.

Need at least a dimension size of 2 so that interpolation works properly.

beam_lw x beam_mh x beam_nud x npol x complex_double
=> 2 x 2 x 2 x 4 x 16 = 512 bytes