### PR TITLE
Handle previously zeroed dims during dim updates

### DIFF
--- a/montblanc/impl/rime/tensorflow/RimeSolver.py
+++ b/montblanc/impl/rime/tensorflow/RimeSolver.py
@@ -1276,6 +1276,10 @@ def _apply_source_provider_dim_updates(cube, source_providers, budget_dims):
         # Defer to existing any existing budgeted extent sizes
         # Otherwise take the global_size
         extent_size = budget_dims.get(name, global_size)
+
+        # Take the global_size if extent_size was previously zero!
+        extent_size = global_size if extent_size == 0 else extent_size
+
         # Clamp extent size to global size
         if extent_size > global_size:
             extent_size = global_size


### PR DESCRIPTION
If a dimension was set to zero during a previous dimension update, then subsequent, larger, dimension updates would never be applied.

Fix this by setting the dimension extent to global_size if it was previously zero.