### PR TITLE
Relax hard requirement on python-casacore 2.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,7 @@ else:
         'cerberus >= 1.1',
         'numpy >= 1.11.3',
         'numexpr >= 2.6.1',
-        'python-casacore == 2.1.2',
+        'python-casacore >= 2.1.2',
         'ruamel.yaml >= 0.15.22',
         "{} == 1.4.0".format(tensorflow_package),
     ]


### PR DESCRIPTION
Allow more recent versions.