### PR TITLE
Support disjoint antenna UVW decompositions

### DIFF
--- a/montblanc/tests/test_antenna_uvw_decomposition.py
+++ b/montblanc/tests/test_antenna_uvw_decomposition.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from montblanc.util import antenna_uvw
 
+
 class TestAntennaUvWDecomposition(unittest.TestCase):
     def test_uvw_antenna(self):
         na = 17
@@ -18,22 +19,49 @@ class TestAntennaUvWDecomposition(unittest.TestCase):
 
             # Create random per-antenna UVW coordinates.
             # zeroing the first antenna
-            ant_uvw = np.random.random(size=(ntime,na,3)).astype(np.float64)
-            ant_uvw[0,0,:] = 0
+            ant_uvw = np.random.random(size=(ntime, na, 3)).astype(np.float64)
+            ant_uvw[0, 0, :] = 0
 
             time_chunks = np.array([ant1.size], dtype=ant1.dtype)
 
             # Compute per-baseline UVW coordinates.
-            bl_uvw =  (ant_uvw[:,ant1,:] - ant_uvw[:,ant2,:]).reshape(-1, 3)
+            bl_uvw = (ant_uvw[:, ant1, :] - ant_uvw[:, ant2, :]).reshape(-1, 3)
 
             # Now recover the per-antenna and per-baseline UVW coordinates.
             rant_uvw = antenna_uvw(bl_uvw, ant1, ant2, time_chunks,
-                                    nr_of_antenna=na, check_decomposition=True)
+                                   nr_of_antenna=na, check_decomposition=True)
 
+    def test_uvw_disjoint(self):
 
-    def test_uvw_antenna_missing_bl(self):
+        # Three initially disjoint baselines here, but the last baseline [2, 9]
+        # connects the first and the last
+        # Set 1: 0, 1, 2, 3
+        # Set 2: 4, 5, 6, 7, 8
+        # Set 3: 8, 10, 11, 12
+        # Connection between Set 1 and Set 3 is the last baseline [2, 9]
+        ant1 = np.array([1,  2,  3,  4,  5,  5,  7,  9, 10, 11,  2])
+        ant2 = np.array([2,  2,  0,  5,  5,  6,  8, 10, 11, 12,  9])
+
+        na = np.unique(np.concatenate([ant1, ant2])).size
+        ntime = 1
+
+        # Create random per-antenna UVW coordinates.
+        # zeroing the first antenna
+        ant_uvw = np.random.random(size=(ntime, na, 3)).astype(np.float64)
+        ant_uvw[0, 0, :] = 0
+
+        time_chunks = np.array([ant1.size], dtype=ant1.dtype)
+
+        # Compute per-baseline UVW coordinates.
+        bl_uvw = (ant_uvw[:, ant1, :] - ant_uvw[:, ant2, :]).reshape(-1, 3)
+
+        # Now recover the per-antenna and per-baseline UVW coordinates.
+        rant_uvw = antenna_uvw(bl_uvw, ant1, ant2, time_chunks,
+                               nr_of_antenna=na, check_decomposition=True)
+
+    def test_uvw_antenna_missing_bl_impl(self):
         na = 17
-        removed_ants_per_time = ([0, 1, 7], [2,10,15,9], [3, 6, 9, 12])
+        removed_ants_per_time = ([0, 1, 7], [2, 10, 15, 9], [3, 6, 9, 12])
 
         # For both auto correlations and without them
         for auto_cor in (0, 1):
@@ -50,9 +78,9 @@ class TestAntennaUvWDecomposition(unittest.TestCase):
                     ant1 = ant1[idx]
                     ant2 = ant2[idx]
 
-                    # Remove any baselines containing flagged antennae
+                    # Remove any baselines containing flagged antenna
                     reduce_tuple = tuple(a != ra for a in (ant1, ant2)
-                                                for ra in remove_ants)
+                                         for ra in remove_ants)
 
                     keep = np.logical_and.reduce(reduce_tuple)
                     ant1 = ant1[keep]
@@ -62,19 +90,20 @@ class TestAntennaUvWDecomposition(unittest.TestCase):
 
                     yield valid_ants, remove_ants, ant1, ant2
 
-
-            valid_ants, remove_ants, ant1, ant2 = zip(*list(_create_ant_arrays()))
+            tup = zip(*list(_create_ant_arrays()))
+            valid_ants, remove_ants, ant1, ant2 = tup
 
             bl_uvw = []
 
             # Create per-baseline UVW coordinates for each time chunk
-            for t, (va, ra, a1, a2) in enumerate(zip(valid_ants, remove_ants, ant1, ant2)):
+            it = enumerate(zip(valid_ants, remove_ants, ant1, ant2))
+            for t, (va, ra, a1, a2) in it:
                 # Create random per-antenna UVW coordinates.
                 # zeroing the first valid antenna
-                ant_uvw = np.random.random(size=(na,3)).astype(np.float64)
-                ant_uvw[va[0],:] = 0
+                ant_uvw = np.random.random(size=(na, 3)).astype(np.float64)
+                ant_uvw[va[0], :] = 0
                 # Create per-baseline UVW coordinates for this time chunk
-                bl_uvw.append(ant_uvw[a1,:] - ant_uvw[a2,:])
+                bl_uvw.append(ant_uvw[a1, :] - ant_uvw[a2, :])
 
             # Produced concatenated antenna and baseline uvw arrays
             time_chunks = np.array([a.size for a in ant1], dtype=ant1[0].dtype)
@@ -85,7 +114,7 @@ class TestAntennaUvWDecomposition(unittest.TestCase):
             # Now recover the per-antenna and per-baseline UVW coordinates
             # for the ntime chunks
             rant_uvw = antenna_uvw(cbl_uvw, cant1, cant2, time_chunks,
-                                nr_of_antenna=na, check_decomposition=True)
+                                   nr_of_antenna=na, check_decomposition=True)
 
 
 if __name__ == "__main__":

--- a/montblanc/util/ant_uvw.py
+++ b/montblanc/util/ant_uvw.py
@@ -3,7 +3,7 @@ from future_builtins import zip
 from itertools import islice
 import math
 import numpy as np
-import numba
+from numba import jit, generated_jit
 
 # Coordinate indexing constants
 u, v, w = range(3)
@@ -11,31 +11,31 @@ u, v, w = range(3)
 try:
     isclose = math.isclose
 except AttributeError:
-    @numba.jit(nopython=True, nogil=True, cache=True)
+    @jit(nopython=True, nogil=True, cache=True)
     def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
         return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
-@numba.jit(nopython=True, nogil=True, cache=True)
+
+@jit(nopython=True, nogil=True, cache=True)
 def _antenna_uvw_loop(uvw, antenna1, antenna2, ant_uvw,
-                                chunk_index, start, end):
+                      chunk_index, start, end):
 
     c = chunk_index
 
-    clusters = {}
-    a1 = antenna1[start]
-    a2 = antenna2[start]
+    # Cluster (first antenna) associated with each antenna
+    clusters = np.full((ant_uvw.shape[1],), -1, dtype=antenna1.dtype)
 
-    # Now do the rest of the rows in this chunk
+    # Iterate over rows in chunk
     for row in range(start, end):
         a1 = antenna1[row]
         a2 = antenna2[row]
 
         # Have they been clustered yet?
-        cl1 = clusters.get(a1)
-        cl2 = clusters.get(a2)
+        cl1 = clusters[a1]
+        cl2 = clusters[a2]
 
         # Both new -- start a new cluster relative to a1
-        if cl1 is None and cl2 is None:
+        if cl1 == -1 and cl2 == -1:
             clusters[a1] = clusters[a2] = a1
             ant_uvw[c, a1, u] = 0.0
             ant_uvw[c, a1, v] = 0.0
@@ -44,38 +44,45 @@ def _antenna_uvw_loop(uvw, antenna1, antenna2, ant_uvw,
             # If this is not an auto-correlation
             # assign a2 to inverse of baseline UVW,
             if a1 != a2:
-                ant_uvw[c, a2, u] = uvw[start, u]
-                ant_uvw[c, a2, v] = uvw[start, v]
-                ant_uvw[c, a2, w] = uvw[start, w]
+                ant_uvw[c, a2, u] = uvw[row, u]
+                ant_uvw[c, a2, v] = uvw[row, v]
+                ant_uvw[c, a2, w] = uvw[row, w]
 
-        ## if either antenna has not been clustered, infer its coodrinate from
-        ## the clustered one
-        elif c11 is not None and cl2 is None:
-            clusters[a2] = a1
-            ant_uvw[c,a2,u] = ant_uvw[c,a1,u] + uvw[row,u]
-            ant_uvw[c,a2,v] = ant_uvw[c,a1,v] + uvw[row,v]
-            ant_uvw[c,a2,w] = ant_uvw[c,a1,w] + uvw[row,w]
-        elif cl1 is None and cl2 is not None:
-            clusters[a1] = a2
-            ant_uvw[c,a1,u] = ant_uvw[c,a2,u] - uvw[row,u]
-            ant_uvw[c,a1,v] = ant_uvw[c,a2,v] - uvw[row,v]
-            ant_uvw[c,a1,w] = ant_uvw[c,a2,w] - uvw[row,w]
-        ## Both clustered. If clusters differ, merge them
-        elif cl1 is not None and cl2 is not None:
+        # if either antenna has not been clustered,
+        # infer its coordinate from the clustered one
+        elif cl1 != -1 and cl2 == -1:
+            clusters[a2] = cl1
+            ant_uvw[c, a2, u] = ant_uvw[c, a1, u] + uvw[row, u]
+            ant_uvw[c, a2, v] = ant_uvw[c, a1, v] + uvw[row, v]
+            ant_uvw[c, a2, w] = ant_uvw[c, a1, w] + uvw[row, w]
+        elif cl1 == -1 and cl2 != -1:
+            clusters[a1] = cl2
+            ant_uvw[c, a1, u] = ant_uvw[c, a2, u] - uvw[row, u]
+            ant_uvw[c, a1, v] = ant_uvw[c, a2, v] - uvw[row, v]
+            ant_uvw[c, a1, w] = ant_uvw[c, a2, w] - uvw[row, w]
+        # Both clustered. If clusters differ, merge them
+        elif cl1 != -1 and cl2 != -1:
             if cl1 != cl2:
-                # how much do we need to add to the current cluster2 reference position
-                # to make the baseline a2-a1 consistent
-                offset = uvw[row,:] - (ant_uvw[c,a2,:] - ant_uvw[c,a1,:])
-                # get all antennas of second cluster
-                for a, cl in clusters.items():
-                    if a == cl2:
-                        clusters[a] = cl1
-                        ant_uvw[c,a,:] += offset
+                # how much do we need to add to the current cluster2
+                # reference position to make the baseline a2 - a1 consistent?
+                u_off = uvw[row, u] - (ant_uvw[c, a2, u] - ant_uvw[c, a1, u])
+                v_off = uvw[row, v] - (ant_uvw[c, a2, v] - ant_uvw[c, a1, v])
+                w_off = uvw[row, w] - (ant_uvw[c, a2, w] - ant_uvw[c, a1, w])
 
+                # Merge cluster2 into cluster1
+                for ant, cluster in enumerate(clusters):
+                    if cluster == cl2:
+                        clusters[ant] = cl1
+                        ant_uvw[c, ant, u] += u_off
+                        ant_uvw[c, ant, v] += v_off
+                        ant_uvw[c, ant, w] += w_off
+
+        # Shouldn't ever occur
+        else:
             raise ValueError("Illegal Condition")
 
 
-@numba.jit(nopython=True, nogil=True, cache=True)
+@jit(nopython=True, nogil=True, cache=True)
 def _antenna_uvw(uvw, antenna1, antenna2, chunks, nr_of_antenna):
     """ numba implementation of antenna_uvw """
 
@@ -90,7 +97,7 @@ def _antenna_uvw(uvw, antenna1, antenna2, chunks, nr_of_antenna):
 
     if not (uvw.shape[0] == antenna1.shape[0] == antenna2.shape[0]):
         raise ValueError("First dimension of uvw, antenna1 "
-                                "and antenna2 do not match")
+                         "and antenna2 do not match")
 
     if chunks.ndim != 1:
         raise ValueError("chunks shape should be (utime,)")
@@ -113,8 +120,10 @@ def _antenna_uvw(uvw, antenna1, antenna2, chunks, nr_of_antenna):
 
     return antenna_uvw
 
+
 class AntennaUVWDecompositionError(Exception):
     pass
+
 
 def _raise_decomposition_errors(uvw, antenna1, antenna2,
                                 chunks, ant_uvw, max_err):
@@ -131,8 +140,8 @@ def _raise_decomposition_errors(uvw, antenna1, antenna2,
         ant2 = antenna2[start:end]
         cuvw = uvw[start:end]
 
-        ant1_uvw = ant_uvw[ci,ant1,:]
-        ant2_uvw = ant_uvw[ci,ant2,:]
+        ant1_uvw = ant_uvw[ci, ant1, :]
+        ant2_uvw = ant_uvw[ci, ant2, :]
         ruvw = ant2_uvw - ant1_uvw
 
         # Identifty rows where any of the UVW components differed
@@ -140,11 +149,10 @@ def _raise_decomposition_errors(uvw, antenna1, antenna2,
         problems = np.nonzero(np.logical_or.reduce(np.invert(close), axis=1))
 
         for row in problems[0]:
-            problem_str.append("[row %d (chunk %d)]: "
-                              "original %s "
-                              "recovered %s "
-                              "ant1 %s "
-                              "ant2 %s" % (start+row, ci,
+            problem_str.append("[row %d [%d, %d] (chunk %d)]: "
+                               "original %s recovered %s "
+                               "ant1 %s ant2 %s" % (
+                                    start+row, ant1[row], ant2[row], ci,
                                     cuvw[row], ruvw[row],
                                     ant1_uvw[row], ant2_uvw[row]))
 
@@ -164,12 +172,14 @@ def _raise_decomposition_errors(uvw, antenna1, antenna2,
 
     # Add a preamble and raise exception
     problem_str = ["Antenna UVW Decomposition Failed",
-                "The following differences were found "
-                "(first 100):"] + problem_str
+                   "The following differences were found "
+                   "(first 100):"] + problem_str
     raise AntennaUVWDecompositionError('\n'.join(problem_str))
+
 
 class AntennaMissingError(Exception):
     pass
+
 
 def _raise_missing_antenna_errors(ant_uvw, max_err):
     """ Raises an informative error for missing antenna """
@@ -180,7 +190,7 @@ def _raise_missing_antenna_errors(ant_uvw, max_err):
     problem_str = []
 
     for c, a in zip(*problems):
-        problem_str.append("[chunk %d antenna %d]" % (c,a))
+        problem_str.append("[chunk %d antenna %d]" % (c, a))
 
         # Exit early
         if len(problem_str) >= max_err:
@@ -193,6 +203,7 @@ def _raise_missing_antenna_errors(ant_uvw, max_err):
     # Add a preamble and raise exception
     problem_str = ["Antenna were missing"] + problem_str
     raise AntennaMissingError('\n'.join(problem_str))
+
 
 def antenna_uvw(uvw, antenna1, antenna2, chunks,
                 nr_of_antenna, check_missing=False,


### PR DESCRIPTION
Previously, all baselines in a timestep were assumed to be related to each other during decomposition of per-baseline UVW coordinates into per-antenna UVW coordinates with a single reference antenna at the origin.

This PR now supports multiple disjoint sets of antenna (each with a reference antenna at origin), which may be merged during decomposition if connecting baselines are found.