### PR TITLE
[WIP] Fixes deadlocking queue inside montblanc

### DIFF
--- a/montblanc/impl/rime/tensorflow/RimeSolver.py
+++ b/montblanc/impl/rime/tensorflow/RimeSolver.py
@@ -523,7 +523,7 @@ class RimeSolver(MontblancTensorflowSolver):
         try:
             with _feederqueuelock:
                 descriptor, enq = self._tfrun(self._tf_expr[shard], feed_dict=feed_dict)
-            self._inputs_waiting.decrement(shard)
+                self._inputs_waiting.decrement(shard)
 
         except Exception as e:
             montblanc.log.exception("Compute Exception")

--- a/setup.py
+++ b/setup.py
@@ -753,7 +753,7 @@ else:
 log.info('install_requires={}'.format(install_requires))
 
 setup(name='montblanc',
-    version="0.7.1",
+    version="0.7.2",
     description='GPU-accelerated RIME implementations.',
     long_description=readme(),
     url='http://github.com/ska-sa/montblanc',


### PR DESCRIPTION
This is a decrement before lock scenario. The feeder queue has its own lock - however before increment can take place on inputs waiting consume must have already tried decrementing the counter and one of the while loops hangs forever at that point. This is non-deterministic.

Specifically this entire block:
```
                try:
                    # Get the descriptor describing a portion of the RIME
                    result = session.run(LSA.descriptor.get_op)
                    descriptor = result['descriptor']
                except tf.errors.OutOfRangeError as e:
                    montblanc.log.exception("Descriptor reading exception")

                # Quit if EOF
                if descriptor[0] == -1:
                    break

                # Make it read-only so we can hash the contents
                descriptor.flags.writeable = False

                # Find indices of the emptiest staging_areas and, by implication
                # the shard with the least work assigned to it
                emptiest_staging_areas = np.argsort(self._inputs_waiting.get())
                shard = emptiest_staging_areas[0]
                shard = next(which_shard)
                feed_f = self._feed_executors[shard].submit(self._feed_actual,
                    data_sources.copy(), cube.copy(),
                    descriptor, shard,
                    src_types, src_strides, src_staging_areas[shard],
                    global_iter_args)

                compute_f = self._compute_executors[shard].submit(self._compute,
                    compute_feed_dict, shard)

                consume_f = self._consumer_executor.submit(self._consume,
                    data_sinks.copy(), cube.copy(), global_iter_args)

                self._inputs_waiting.increment(shard)

                yield (feed_f, compute_f, consume_f)

                chunks_fed += 1
```
ought to be inside a lock because there are variables outside the _inputs_waiting queue that must only be updated while the lock is held by the queue